### PR TITLE
Fix: add minimal panel_new (unblocks runserver)

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,7 +1,7 @@
 # core/views.py
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseNotAllowed
-from django.shortcuts import render, get_object_or_404, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from xml.etree.ElementTree import Element, SubElement, tostring
 from django.utils.encoding import smart_str
 
@@ -206,3 +206,12 @@ def export_cian(request):
 
     xml_bytes = tostring(root, encoding="utf-8", xml_declaration=True)
     return HttpResponse(xml_bytes, content_type="application/xml; charset=utf-8")
+
+
+def panel_new(request):
+    """
+    Страница создания нового объекта (временная заглушка).
+    Пока просто рендерим форму без сохранения, чтобы убрать  AttributeError.
+    """
+    form = PropertyForm()
+    return render(request, "core/panel_edit.html", {"form": form, "prop": None, "photos": []})


### PR DESCRIPTION
## Summary
- ensure the core.views module imports redirect in the same line as render and get_object_or_404
- add a temporary panel_new view that renders the existing panel_edit template with an empty form

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfff278bf48320ad7860b152410f67