### PR TITLE
Remove shared key from panel access

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -7,9 +7,7 @@ from django.utils.encoding import smart_str
 
 from .models import Property, Photo
 from .forms import PropertyForm, PhotoForm
-from .guards import shared_key_required
 
-@shared_key_required
 def panel_list(request):
     q = request.GET.get("q", "").strip()
     props = Property.objects.all()
@@ -22,7 +20,6 @@ def panel_list(request):
     props = props.order_by("-updated_at", "-id")
     return render(request, "core/panel_list.html", {"props": props, "q": q})
 
-@shared_key_required
 def panel_new(request):
     """
     Создание объекта:


### PR DESCRIPTION
## Summary
- remove the shared key guard import and decorator from panel views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00a97983883209ce6f9753c548655