### PR TITLE
Feature: panel_edit basic (no photos yet)

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -36,17 +36,20 @@ def panel_new(request):
     return render(request, "core/panel_edit.html", {"form": form, "prop": None, "photos": []})
 
 def panel_edit(request, pk):
+    """
+    Редактирование существующего объекта (без фото-логики).
+    """
     prop = get_object_or_404(Property, pk=pk)
     if request.method == "POST":
         form = PropertyForm(request.POST, instance=prop)
         if form.is_valid():
-            obj = form.save()
-            return redirect(f"/panel/edit/{obj.pk}/")
+            form.save()
+            # остаёмся на этой же странице
+            return redirect(f"/panel/edit/{prop.pk}/")
     else:
         form = PropertyForm(instance=prop)
-    photos = prop.photos.all()
-    photo_form = PhotoForm()
-    return render(request, "core/panel_edit.html", {"form": form, "prop": prop, "photos": photos, "photo_form": photo_form})
+    # пока без фактических фото — отдадим пустой список для шаблона
+    return render(request, "core/panel_edit.html", {"form": form, "prop": prop, "photos": []})
 
 def panel_add_photo(request, pk):
     if request.method != "POST":


### PR DESCRIPTION
## Summary
- simplify the panel_edit view to only handle property form editing without photo logic
- keep the user on the edit page after successful updates and provide an empty photos list for the template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00b362a508320a7a50e3f8436cc8c