### PR TITLE
New object wizard: step 1

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,6 +1,22 @@
 # core/forms.py
 from django import forms
+from django.core.exceptions import FieldDoesNotExist
+
 from .models import Property, Photo
+
+
+def _build_choices(model_attr_name, fallback_values, field_name=None):
+    choices = getattr(Property, model_attr_name, None)
+    if choices:
+        return choices
+    if field_name:
+        try:
+            model_field = Property._meta.get_field(field_name)
+            if model_field.choices:
+                return model_field.choices
+        except FieldDoesNotExist:
+            pass
+    return [(value, value) for value in fallback_values]
 
 class PropertyForm(forms.ModelForm):
     class Meta:
@@ -36,3 +52,20 @@ class PhotoForm(forms.ModelForm):
     class Meta:
         model = Photo
         fields = ["full_url","is_default"]
+
+
+class NewObjectStep1Form(forms.Form):
+    category = forms.ChoiceField(
+        choices=_build_choices(
+            "CATEGORY_CHOICES",
+            ["flat", "house", "room", "land", "commercial"],
+            field_name="category",
+        )
+    )
+    operation = forms.ChoiceField(
+        choices=_build_choices(
+            "OPERATION_CHOICES",
+            ["sale", "rent"],
+            field_name="operation",
+        )
+    )

--- a/core/templates/core/panel_new_step1.html
+++ b/core/templates/core/panel_new_step1.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Новый объект — шаг 1{% endblock %}
+{% block content %}
+  <h1>Новый объект: шаг 1</h1>
+  <form method="post">
+    {% csrf_token %}
+    <div class="form-row">
+      {{ form.category.label_tag }}
+      {{ form.category }}
+    </div>
+    <div class="form-row">
+      {{ form.operation.label_tag }}
+      {{ form.operation }}
+    </div>
+    <button type="submit">Далее</button>
+  </form>
+{% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -8,7 +8,7 @@ from xml.etree.ElementTree import Element, SubElement, tostring
 from django.utils.encoding import smart_str
 
 from .models import Property, Photo
-from .forms import PropertyForm, PhotoForm
+from .forms import PropertyForm, PhotoForm, NewObjectStep1Form
 
 def panel_list(request):
     q = request.GET.get("q", "").strip()
@@ -23,19 +23,17 @@ def panel_list(request):
     return render(request, "core/panel_list.html", {"props": props, "q": q})
 
 def panel_new(request):
-    """
-    Создание объекта:
-    GET  -> пустая форма
-    POST -> сохранить и перейти на редактирование созданного объекта
-    """
     if request.method == "POST":
-        form = PropertyForm(request.POST)
+        form = NewObjectStep1Form(request.POST)
         if form.is_valid():
-            prop = form.save()
+            prop = Property.objects.create(
+                category=form.cleaned_data["category"],
+                operation=form.cleaned_data["operation"],
+            )
             return redirect(f"/panel/edit/{prop.pk}/")
     else:
-        form = PropertyForm()
-    return render(request, "core/panel_edit.html", {"form": form, "prop": None, "photos": []})
+        form = NewObjectStep1Form()
+    return render(request, "core/panel_new_step1.html", {"form": form})
 
 def panel_edit(request, pk):
     """


### PR DESCRIPTION
## Summary
- add a dedicated form for the first step of the new object wizard with category and operation choices
- update the panel_new view to use the new step-1 form and create a draft property before redirecting to editing
- add a step-1 template with the basic form layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e01e39b8a48320985519b045f46157