### PR TITLE
UI: show relevant groups only

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -17,6 +17,9 @@
     .form-row { display:grid; grid-template-columns: 1fr; gap:.6rem; margin:.4rem 0; }
     .form-row.row-2 { grid-template-columns: 1fr 1fr; }
     .form-row.row-2 .form-row { margin: 0; }
+    .group { margin: 2rem 0; padding: 1rem 0; border-top: 1px solid #dde; }
+    .group:first-of-type { border-top: none; padding-top: 0; }
+    .group > h3 { margin-bottom: .6rem; }
     label { margin-bottom:.2rem; font-weight:600; font-size:.9em; }
     button,
     .button,
@@ -52,5 +55,74 @@
     </nav>
     {% block content %}{% endblock %}
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const categorySelect = document.querySelector('select[name="category"]');
+      const operationSelect = document.querySelector('select[name="operation"]');
+
+      const normalizeCategory = (value) => {
+        if (!value) return null;
+        const low = value.toLowerCase();
+        if (low.includes('flat') || low.includes('apartment')) return 'flat';
+        if (low.includes('room') || low.includes('bed')) return 'room';
+        if (low.includes('house') || low.includes('cottage') || low.includes('townhouse')) return 'house';
+        if (low.includes('land')) return 'land';
+        if (low.includes('office') || low.includes('industry') || low.includes('warehouse') ||
+            low.includes('shopping') || low.includes('commercial') || low.includes('business') ||
+            low.includes('building') || low.includes('garage') || low.includes('freeappointment')) {
+          return 'commercial';
+        }
+        return value;
+      };
+
+      const resolveOperation = () => {
+        if (operationSelect && operationSelect.value) {
+          return operationSelect.value.toLowerCase();
+        }
+        if (!categorySelect || !categorySelect.value) {
+          return null;
+        }
+        const low = categorySelect.value.toLowerCase();
+        if (low.includes('rent')) return 'rent';
+        if (low.includes('sale')) return 'sale';
+        return null;
+      };
+
+      const splitAttr = (value) => {
+        if (!value) return null;
+        return value.split(',').map((item) => item.trim().toLowerCase()).filter(Boolean);
+      };
+
+      const updateGroups = () => {
+        const rawCategory = categorySelect ? categorySelect.value : null;
+        const normalizedCategory = normalizeCategory(rawCategory);
+        const categoryCandidates = [];
+        if (normalizedCategory) categoryCandidates.push(normalizedCategory.toLowerCase());
+        if (rawCategory) categoryCandidates.push(rawCategory.toLowerCase());
+
+        const operationValue = resolveOperation();
+
+        document.querySelectorAll('section.group').forEach((section) => {
+          const catAttr = splitAttr(section.dataset.cat);
+          const opAttr = splitAttr(section.dataset.op);
+
+          const categoryMatches = !catAttr || categoryCandidates.length === 0 ||
+            categoryCandidates.some((candidate) => catAttr.includes(candidate));
+          const operationMatches = !opAttr || !operationValue || opAttr.includes(operationValue);
+
+          section.style.display = categoryMatches && operationMatches ? '' : 'none';
+        });
+      };
+
+      if (categorySelect) {
+        categorySelect.addEventListener('change', updateGroups);
+      }
+      if (operationSelect) {
+        operationSelect.addEventListener('change', updateGroups);
+      }
+
+      updateGroups();
+    });
+  </script>
 </body>
 </html>

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -7,181 +7,332 @@
   <form method="post">
     {% csrf_token %}
 
-    <h3>Основное</h3>
-    <div class="form-row">
-      {{ form.title.label_tag }}
-      {{ form.title }}
-    </div>
-    <div class="form-row">
-      {{ form.external_id.label_tag }}
-      {{ form.external_id }}
-    </div>
-    <div class="form-row">
-      {{ form.category.label_tag }}
-      {{ form.category }}
-    </div>
-    <div class="form-row">
-      {{ form.operation.label_tag }}
-      {{ form.operation }}
-    </div>
-    <div class="form-row row-2">
+    <section class="group" data-op="sale,rent">
+      <h3>Основное</h3>
       <div class="form-row">
-        {{ form.price.label_tag }}
-        {{ form.price }}
+        {{ form.external_id.label_tag }}
+        {{ form.external_id }}
       </div>
       <div class="form-row">
-        {{ form.currency.label_tag }}
-        {{ form.currency }}
+        {{ form.category.label_tag }}
+        {{ form.category }}
       </div>
-    </div>
+      <div class="form-row">
+        {{ form.title.label_tag }}
+        {{ form.title }}
+      </div>
+      <div class="form-row">
+        {{ form.description.label_tag }}
+        {{ form.description }}
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.price.label_tag }}
+          {{ form.price }}
+        </div>
+        <div class="form-row">
+          {{ form.currency.label_tag }}
+          {{ form.currency }}
+        </div>
+      </div>
+      <div class="form-row">
+        <label>{{ form.mortgage_allowed }} {{ form.mortgage_allowed.label }}</label>
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.agent_bonus_value.label_tag }}
+          {{ form.agent_bonus_value }}
+        </div>
+        <div class="form-row">
+          <label>{{ form.agent_bonus_is_percent }} {{ form.agent_bonus_is_percent.label }}</label>
+        </div>
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.security_deposit.label_tag }}
+          {{ form.security_deposit }}
+        </div>
+        <div class="form-row">
+          {{ form.min_rent_term_months.label_tag }}
+          {{ form.min_rent_term_months }}
+        </div>
+      </div>
+    </section>
 
-    <h3>Адрес</h3>
-    <div class="form-row">
-      {{ form.city.label_tag }}
-      {{ form.city }}
-    </div>
-    <div class="form-row">
-      {{ form.address.label_tag }}
-      {{ form.address }}
-    </div>
-    <div class="form-row row-2">
+    <section class="group" data-op="sale,rent">
+      <h3>Адрес</h3>
       <div class="form-row">
-        {{ form.lat.label_tag }}
-        {{ form.lat }}
+        {{ form.address.label_tag }}
+        {{ form.address }}
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.lat.label_tag }}
+          {{ form.lat }}
+        </div>
+        <div class="form-row">
+          {{ form.lng.label_tag }}
+          {{ form.lng }}
+        </div>
       </div>
       <div class="form-row">
-        {{ form.lng.label_tag }}
-        {{ form.lng }}
+        {{ form.cadastral_number.label_tag }}
+        {{ form.cadastral_number }}
       </div>
-    </div>
-    <div class="form-row">
-      {{ form.cadastral_number.label_tag }}
-      {{ form.cadastral_number }}
-    </div>
+    </section>
 
-    <h3>Площади и этаж</h3>
-    <div class="form-row">
-      {{ form.rooms.label_tag }}
-      {{ form.rooms }}
-    </div>
-    <div class="form-row">
-      {{ form.area_total.label_tag }}
-      {{ form.area_total }}
-    </div>
-    <div class="form-row">
-      {{ form.area_living.label_tag }}
-      {{ form.area_living }}
-    </div>
-    <div class="form-row">
-      {{ form.area_kitchen.label_tag }}
-      {{ form.area_kitchen }}
-    </div>
-    <div class="form-row row-2">
-      <div class="form-row">
-        {{ form.floor.label_tag }}
-        {{ form.floor }}
+    <section class="group" data-op="sale,rent">
+      <h3>Контакты</h3>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.phone_country.label_tag }}
+          {{ form.phone_country }}
+        </div>
+        <div class="form-row">
+          {{ form.phone_number.label_tag }}
+          {{ form.phone_number }}
+        </div>
       </div>
       <div class="form-row">
-        {{ form.floors_total.label_tag }}
-        {{ form.floors_total }}
+        {{ form.phone_number2.label_tag }}
+        {{ form.phone_number2 }}
       </div>
-    </div>
+    </section>
 
-    <h3>Характеристики</h3>
-    <div class="form-row">
-      <label>{{ form.is_euro_flat }} Европланировка</label>
-    </div>
-    <div class="form-row">
-      <label>{{ form.is_apartments }} Апартаменты</label>
-    </div>
-    <div class="form-row">
-      <label>{{ form.is_penthouse }} Пентхаус</label>
-    </div>
-    <div class="form-row">
-      {{ form.balconies_count.label_tag }}
-      {{ form.balconies_count }}
-    </div>
-    <div class="form-row">
-      {{ form.loggias_count.label_tag }}
-      {{ form.loggias_count }}
-    </div>
-    <div class="form-row">
-      {{ form.separate_wcs_count.label_tag }}
-      {{ form.separate_wcs_count }}
-    </div>
-    <div class="form-row">
-      {{ form.combined_wcs_count.label_tag }}
-      {{ form.combined_wcs_count }}
-    </div>
-    <div class="form-row">
-      {{ form.repair_type.label_tag }}
-      {{ form.repair_type }}
-    </div>
-    <div class="form-row">
-      {{ form.windows_view_type.label_tag }}
-      {{ form.windows_view_type }}
-    </div>
-    <div class="form-row">
-      <label>{{ form.has_internet }} Интернет</label>
-    </div>
-    <div class="form-row">
-      <label>{{ form.has_furniture }} Есть мебель</label>
-    </div>
-    <div class="form-row">
-      <label>{{ form.has_phone }} Телефонная линия</label>
-    </div>
-    <div class="form-row">
-      <label>{{ form.has_kitchen_furniture }} Мебель на кухне</label>
-    </div>
+    <section class="group" data-op="sale,rent">
+      <h3>Медиа</h3>
+      <div class="form-row">
+        {{ form.layout_photo_url.label_tag }}
+        {{ form.layout_photo_url }}
+      </div>
+      <div class="form-row">
+        {{ form.object_tour_url.label_tag }}
+        {{ form.object_tour_url }}
+      </div>
+    </section>
 
-    <h3>Метро (до 3 станций)</h3>
-    <div class="form-row">
-      {{ form.metro1_id.label_tag }}
-      {{ form.metro1_id }}
-    </div>
-    <div class="form-row row-2">
+    <section class="group" data-op="sale,rent">
+      <h3>Здание</h3>
       <div class="form-row">
-        {{ form.metro1_time.label_tag }}
-        {{ form.metro1_time }}
+        {{ form.building_name.label_tag }}
+        {{ form.building_name }}
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.building_floors.label_tag }}
+          {{ form.building_floors }}
+        </div>
+        <div class="form-row">
+          {{ form.building_build_year.label_tag }}
+          {{ form.building_build_year }}
+        </div>
       </div>
       <div class="form-row">
-        {{ form.metro1_transport_type.label_tag }}
-        {{ form.metro1_transport_type }}
+        {{ form.building_material.label_tag }}
+        {{ form.building_material }}
       </div>
-    </div>
-    <div class="form-row">
-      {{ form.metro2_id.label_tag }}
-      {{ form.metro2_id }}
-    </div>
-    <div class="form-row row-2">
-      <div class="form-row">
-        {{ form.metro2_time.label_tag }}
-        {{ form.metro2_time }}
-      </div>
-      <div class="form-row">
-        {{ form.metro2_transport_type.label_tag }}
-        {{ form.metro2_transport_type }}
-      </div>
-    </div>
-    <div class="form-row">
-      {{ form.metro3_id.label_tag }}
-      {{ form.metro3_id }}
-    </div>
-    <div class="form-row row-2">
-      <div class="form-row">
-        {{ form.metro3_time.label_tag }}
-        {{ form.metro3_time }}
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.building_ceiling_height.label_tag }}
+          {{ form.building_ceiling_height }}
+        </div>
+        <div class="form-row">
+          {{ form.building_passenger_lifts.label_tag }}
+          {{ form.building_passenger_lifts }}
+        </div>
       </div>
       <div class="form-row">
-        {{ form.metro3_transport_type.label_tag }}
-        {{ form.metro3_transport_type }}
+        {{ form.building_cargo_lifts.label_tag }}
+        {{ form.building_cargo_lifts }}
       </div>
-    </div>
+    </section>
 
-    <div class="form-row">
-      {{ form.description.label_tag }}
-      {{ form.description }}
-    </div>
+    <section class="group" data-cat="flat,room">
+      <h3>Квартира / Комната</h3>
+      <div class="form-row">
+        {{ form.room_type.label_tag }}
+        {{ form.room_type }}
+      </div>
+      <div class="form-row">
+        {{ form.flat_rooms_count.label_tag }}
+        {{ form.flat_rooms_count }}
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.total_area.label_tag }}
+          {{ form.total_area }}
+        </div>
+        <div class="form-row">
+          {{ form.living_area.label_tag }}
+          {{ form.living_area }}
+        </div>
+      </div>
+      <div class="form-row">
+        {{ form.kitchen_area.label_tag }}
+        {{ form.kitchen_area }}
+      </div>
+      <div class="form-row">
+        {{ form.floor_number.label_tag }}
+        {{ form.floor_number }}
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.loggias_count.label_tag }}
+          {{ form.loggias_count }}
+        </div>
+        <div class="form-row">
+          {{ form.balconies_count.label_tag }}
+          {{ form.balconies_count }}
+        </div>
+      </div>
+      <div class="form-row">
+        {{ form.windows_view_type.label_tag }}
+        {{ form.windows_view_type }}
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.separate_wcs_count.label_tag }}
+          {{ form.separate_wcs_count }}
+        </div>
+        <div class="form-row">
+          {{ form.combined_wcs_count.label_tag }}
+          {{ form.combined_wcs_count }}
+        </div>
+      </div>
+      <div class="form-row">
+        {{ form.repair_type.label_tag }}
+        {{ form.repair_type }}
+      </div>
+      <div class="form-row">
+        <label>{{ form.is_euro_flat }} {{ form.is_euro_flat.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.is_apartments }} {{ form.is_apartments.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.is_penthouse }} {{ form.is_penthouse.label }}</label>
+      </div>
+    </section>
+
+    <section class="group" data-cat="flat,room">
+      <h3>ЖК и корпус</h3>
+      <div class="form-row">
+        {{ form.jk_id.label_tag }}
+        {{ form.jk_id }}
+      </div>
+      <div class="form-row">
+        {{ form.jk_name.label_tag }}
+        {{ form.jk_name }}
+      </div>
+      <div class="form-row">
+        {{ form.house_id.label_tag }}
+        {{ form.house_id }}
+      </div>
+      <div class="form-row">
+        {{ form.house_name.label_tag }}
+        {{ form.house_name }}
+      </div>
+      <div class="form-row">
+        {{ form.flat_number.label_tag }}
+        {{ form.flat_number }}
+      </div>
+      <div class="form-row">
+        {{ form.section_number.label_tag }}
+        {{ form.section_number }}
+      </div>
+    </section>
+
+    <section class="group" data-cat="house">
+      <h3>Дом и участок</h3>
+      <div class="form-row">
+        {{ form.heating_type.label_tag }}
+        {{ form.heating_type }}
+      </div>
+      <div class="form-row row-2">
+        <div class="form-row">
+          {{ form.land_area.label_tag }}
+          {{ form.land_area }}
+        </div>
+        <div class="form-row">
+          {{ form.land_area_unit.label_tag }}
+          {{ form.land_area_unit }}
+        </div>
+      </div>
+      <div class="form-row">
+        {{ form.permitted_land_use.label_tag }}
+        {{ form.permitted_land_use }}
+      </div>
+      <div class="form-row">
+        {{ form.land_category.label_tag }}
+        {{ form.land_category }}
+      </div>
+      <div class="form-row">
+        <label>{{ form.is_land_with_contract }} {{ form.is_land_with_contract.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_terrace }} {{ form.has_terrace.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_cellar }} {{ form.has_cellar.label }}</label>
+      </div>
+    </section>
+
+    <section class="group" data-cat="commercial">
+      <h3>Коммерция</h3>
+      <div class="form-row">
+        <label>{{ form.is_rent_by_parts }} {{ form.is_rent_by_parts.label }}</label>
+      </div>
+      <div class="form-row">
+        {{ form.rent_by_parts_desc.label_tag }}
+        {{ form.rent_by_parts_desc }}
+      </div>
+      <div class="form-row">
+        {{ form.ceiling_height.label_tag }}
+        {{ form.ceiling_height }}
+      </div>
+      <div class="form-row">
+        {{ form.power.label_tag }}
+        {{ form.power }}
+      </div>
+      <div class="form-row">
+        {{ form.parking_places.label_tag }}
+        {{ form.parking_places }}
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_parking }} {{ form.has_parking.label }}</label>
+      </div>
+    </section>
+
+    <section class="group" data-cat="flat,room,house">
+      <h3>Удобства</h3>
+      <div class="form-row">
+        <label>{{ form.has_internet }} {{ form.has_internet.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_furniture }} {{ form.has_furniture.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_kitchen_furniture }} {{ form.has_kitchen_furniture.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_tv }} {{ form.has_tv.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_washer }} {{ form.has_washer.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_conditioner }} {{ form.has_conditioner.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_phone }} {{ form.has_phone.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_ramp }} {{ form.has_ramp.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_bathtub }} {{ form.has_bathtub.label }}</label>
+      </div>
+    </section>
 
     <button type="submit">Сохранить</button>
   </form>


### PR DESCRIPTION
## Summary
- reorganize the edit panel into typed <section class="group"> blocks and expose all property fields
- add client-side logic to show or hide groups based on selected category and operation values
- ensure category/operation selects remain enabled when editing existing objects

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e01f7ae8d08320986638b178dff391