### PR TITLE
Form: add total_area; model if missing

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -51,6 +51,7 @@ class PropertyForm(forms.ModelForm):
 
         labels = {
             "furnishing_details": "Комплектация",
+            "total_area": "Общая площадь, м²",
         }
 
         widgets = {

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -157,15 +157,12 @@
         {{ form.flat_rooms_count.label_tag }}
         {{ form.flat_rooms_count }}
       </div>
-      <div class="form-row row-2">
-        <div class="form-row">
-          {{ form.total_area.label_tag }}
-          {{ form.total_area }}
-        </div>
-        <div class="form-row">
-          {{ form.living_area.label_tag }}
-          {{ form.living_area }}
-        </div>
+      <div class="form-row">
+        {{ form.total_area.label_tag }} {{ form.total_area }}
+      </div>
+      <div class="form-row">
+        {{ form.living_area.label_tag }}
+        {{ form.living_area }}
       </div>
       <div class="form-row">
         {{ form.kitchen_area.label_tag }}
@@ -302,8 +299,7 @@
         {{ form.rent_by_parts_desc }}
       </div>
       <div class="form-row">
-        {{ form.total_area.label_tag }}
-        {{ form.total_area }}
+        {{ form.total_area.label_tag }} {{ form.total_area }}
       </div>
       <div class="form-row">
         {{ form.ceiling_height.label_tag }}


### PR DESCRIPTION
## Summary
- add an explicit label for the total_area field in PropertyForm
- render the total_area input in the edit panel using the single-row layout

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e0db1fcf4c8320ae4a4324c9bb33e2