### PR TITLE
Wizard step1: choose category/deal and create draft (safe)

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -72,17 +72,15 @@ class PhotoForm(forms.ModelForm):
 
 
 class NewObjectStep1Form(forms.Form):
-    category = forms.ChoiceField(
-        choices=_build_choices(
-            "CATEGORY_CHOICES",
-            ["flat", "house", "room", "land", "commercial"],
-            field_name="category",
-        )
-    )
-    operation = forms.ChoiceField(
-        choices=_build_choices(
-            "OPERATION_CHOICES",
-            ["sale", "rent"],
-            field_name="operation",
-        )
-    )
+    # choices из модели, если есть; иначе — дефолты
+    CATEGORY_CHOICES = getattr(Property, "CATEGORY_CHOICES", [
+        ("flat", "Квартира"), ("room", "Комната"),
+        ("house", "Дом/коттедж"), ("commercial", "Коммерческая"),
+    ])
+    # поле operation может отсутствовать в модели — форму всё равно показываем
+    OPERATION_CHOICES = getattr(Property, "OPERATION_CHOICES", [
+        ("sale", "Продажа"), ("rent", "Аренда"),
+    ])
+
+    category  = forms.ChoiceField(choices=CATEGORY_CHOICES, label="Тип объекта")
+    operation = forms.ChoiceField(choices=OPERATION_CHOICES, label="Тип сделки", required=False)

--- a/core/templates/core/panel_new_step1.html
+++ b/core/templates/core/panel_new_step1.html
@@ -1,17 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Новый объект — шаг 1{% endblock %}
 {% block content %}
-  <h1>Новый объект: шаг 1</h1>
-  <form method="post">
-    {% csrf_token %}
-    <div class="form-row">
-      {{ form.category.label_tag }}
-      {{ form.category }}
-    </div>
-    <div class="form-row">
-      {{ form.operation.label_tag }}
-      {{ form.operation }}
-    </div>
+  <h1>Новый объект</h1>
+  <form method="post">{% csrf_token %}
+    <div class="form-row">{{ form.category.label_tag }} {{ form.category }}</div>
+    {# показываем поле сделки, даже если его потом некуда сохранять — это пригодится позже #}
+    <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
     <button type="submit">Далее</button>
   </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace the step 1 form with safe category/operation choices that fall back to defaults when model choices are missing
- update the /panel/new view to create draft properties defensively when category or operation fields are absent
- simplify the step 1 template with a minimal form layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f9fb3e3c83208faa9f8770174257