### PR TITLE
UI: show relevant sections by category/operation (client-side)

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -56,73 +56,29 @@
     {% block content %}{% endblock %}
   </main>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const categorySelect = document.querySelector('select[name="category"]');
-      const operationSelect = document.querySelector('select[name="operation"]');
+document.addEventListener('DOMContentLoaded', function(){
+  function g(id){ return document.getElementById(id); }
+  function val(id){ const el = g(id); return el ? (el.value||'').trim() : ''; }
 
-      const normalizeCategory = (value) => {
-        if (!value) return null;
-        const low = value.toLowerCase();
-        if (low.includes('flat') || low.includes('apartment')) return 'flat';
-        if (low.includes('room') || low.includes('bed')) return 'room';
-        if (low.includes('house') || low.includes('cottage') || low.includes('townhouse')) return 'house';
-        if (low.includes('land')) return 'land';
-        if (low.includes('office') || low.includes('industry') || low.includes('warehouse') ||
-            low.includes('shopping') || low.includes('commercial') || low.includes('business') ||
-            low.includes('building') || low.includes('garage') || low.includes('freeappointment')) {
-          return 'commercial';
-        }
-        return value;
-      };
-
-      const resolveOperation = () => {
-        if (operationSelect && operationSelect.value) {
-          return operationSelect.value.toLowerCase();
-        }
-        if (!categorySelect || !categorySelect.value) {
-          return null;
-        }
-        const low = categorySelect.value.toLowerCase();
-        if (low.includes('rent')) return 'rent';
-        if (low.includes('sale')) return 'sale';
-        return null;
-      };
-
-      const splitAttr = (value) => {
-        if (!value) return null;
-        return value.split(',').map((item) => item.trim().toLowerCase()).filter(Boolean);
-      };
-
-      const updateGroups = () => {
-        const rawCategory = categorySelect ? categorySelect.value : null;
-        const normalizedCategory = normalizeCategory(rawCategory);
-        const categoryCandidates = [];
-        if (normalizedCategory) categoryCandidates.push(normalizedCategory.toLowerCase());
-        if (rawCategory) categoryCandidates.push(rawCategory.toLowerCase());
-
-        const operationValue = resolveOperation();
-
-        document.querySelectorAll('section.group').forEach((section) => {
-          const catAttr = splitAttr(section.dataset.cat);
-          const opAttr = splitAttr(section.dataset.op);
-
-          const categoryMatches = !catAttr || categoryCandidates.length === 0 ||
-            categoryCandidates.some((candidate) => catAttr.includes(candidate));
-          const operationMatches = !opAttr || !operationValue || opAttr.includes(operationValue);
-
-          section.style.display = categoryMatches && operationMatches ? '' : 'none';
-        });
-      };
-
-      if (categorySelect) {
-        categorySelect.addEventListener('change', updateGroups);
-      }
-      if (operationSelect) {
-        operationSelect.addEventListener('change', updateGroups);
-      }
-
-      updateGroups();
+  function updateGroups(){
+    const cat = val('id_category');
+    const op  = val('id_operation');
+    document.querySelectorAll('.group').forEach(sec => {
+      const cats = (sec.dataset.cat||'').split(',').map(s=>s.trim()).filter(Boolean);
+      const ops  = (sec.dataset.op ||'').split(',').map(s=>s.trim()).filter(Boolean);
+      const catOK = !cats.length || (cat && cats.includes(cat));
+      const opOK  = !ops.length  || (op  && ops.includes(op));
+      sec.style.display = (catOK && opOK) ? '' : 'none';
     });
+  }
+
+  ['id_category','id_operation'].forEach(id=>{
+    const el = g(id);
+    if (el) el.addEventListener('change', updateGroups);
+  });
+
+  updateGroups();
+});
   </script>
 </body>
 </html>

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -7,19 +7,20 @@
   <form method="post">
     {% csrf_token %}
 
-    <section class="group" data-op="sale,rent">
+    <div class="form-row">
+      {{ form.category.label_tag }} {{ form.category }}
+    </div>
+    {% if form.fields.operation %}
+      <div class="form-row">
+        {{ form.operation.label_tag }} {{ form.operation }}
+      </div>
+    {% endif %}
+
+    <section class="group">
       <h3>Основное</h3>
       <div class="form-row">
         {{ form.external_id.label_tag }}
         {{ form.external_id }}
-      </div>
-      <div class="form-row">
-        {{ form.category.label_tag }}
-        {{ form.category }}
-      </div>
-      <div class="form-row">
-        {{ form.operation.label_tag }}
-        {{ form.operation }}
       </div>
       <div class="form-row">
         {{ form.title.label_tag }}
@@ -76,7 +77,7 @@
       </div>
     </section>
 
-    <section class="group" data-op="sale,rent">
+    <section class="group">
       <h3>Адрес</h3>
       <div class="form-row">
         {{ form.address.label_tag }}
@@ -98,7 +99,7 @@
       </div>
     </section>
 
-    <section class="group" data-op="sale,rent">
+    <section class="group">
       <h3>Контакты</h3>
       <div class="form-row row-2">
         <div class="form-row">
@@ -116,7 +117,7 @@
       </div>
     </section>
 
-    <section class="group" data-op="sale,rent">
+    <section class="group">
       <h3>Медиа</h3>
       <div class="form-row">
         {{ form.layout_photo_url.label_tag }}
@@ -128,7 +129,7 @@
       </div>
     </section>
 
-    <section class="group" data-op="sale,rent">
+    <section class="group">
       <h3>Здание</h3>
       <div class="form-row">
         {{ form.building_name.label_tag }}
@@ -249,7 +250,7 @@
     </section>
 
     <section class="group" data-cat="house">
-      <h3>Дом и участок</h3>
+      <h3>Дом</h3>
       <div class="form-row">
         {{ form.heating_type.label_tag }}
         {{ form.heating_type }}


### PR DESCRIPTION
## Summary
- reorganize the panel edit form into grouped sections with category/operation controls and dedicated data attributes for housing, house, and commercial fields
- ensure core and area sections stay visible for all listings while adjusting the base template script to toggle sections client-side without relying on missing fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0fab6c0608320abc21420225b5886