### PR TITLE
UI: no repeated type selection; sections from dataset

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -56,29 +56,35 @@
     {% block content %}{% endblock %}
   </main>
   <script>
-document.addEventListener('DOMContentLoaded', function(){
-  function g(id){ return document.getElementById(id); }
-  function val(id){ const el = g(id); return el ? (el.value||'').trim() : ''; }
-
-  function updateGroups(){
-    const cat = val('id_category');
-    const op  = val('id_operation');
-    document.querySelectorAll('.group').forEach(sec => {
-      const cats = (sec.dataset.cat||'').split(',').map(s=>s.trim()).filter(Boolean);
-      const ops  = (sec.dataset.op ||'').split(',').map(s=>s.trim()).filter(Boolean);
-      const catOK = !cats.length || (cat && cats.includes(cat));
-      const opOK  = !ops.length  || (op  && ops.includes(op));
-      sec.style.display = (catOK && opOK) ? '' : 'none';
+  document.addEventListener('DOMContentLoaded', function(){
+    function byId(id){ return document.getElementById(id); }
+    function getCatOp(){
+      var form = document.querySelector('form[data-cat]');
+      var catData = form ? (form.getAttribute('data-cat') || '').trim() : '';
+      var opData  = form ? (form.getAttribute('data-op')  || '').trim() : '';
+      var catSel = byId('id_category');
+      var opSel  = byId('id_operation');
+      return {
+        cat: catSel ? (catSel.value||'').trim() : catData,
+        op:  opSel  ? (opSel.value||'').trim()  : opData
+      };
+    }
+    function updateGroups(){
+      var cur = getCatOp();
+      document.querySelectorAll('.group').forEach(function(sec){
+        var cats = (sec.dataset.cat||'').split(',').map(function(s){return s.trim();}).filter(Boolean);
+        var ops  = (sec.dataset.op ||'').split(',').map(function(s){return s.trim();}).filter(Boolean);
+        var catOK = !cats.length || (cur.cat && cats.includes(cur.cat));
+        var opOK  = !ops.length  || (cur.op  && ops.includes(cur.op));
+        sec.style.display = (catOK && opOK) ? '' : 'none';
+      });
+    }
+    ['id_category','id_operation'].forEach(function(id){
+      var el = byId(id);
+      if (el) el.addEventListener('change', updateGroups);
     });
-  }
-
-  ['id_category','id_operation'].forEach(id=>{
-    const el = g(id);
-    if (el) el.addEventListener('change', updateGroups);
+    updateGroups();
   });
-
-  updateGroups();
-});
   </script>
 </body>
 </html>

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -4,17 +4,29 @@
   <a href="/panel/">&larr; к списку</a>
   <h1>{{ prop|default:"Новый объект" }}</h1>
 
-  <form method="post">
+  <form method="post"
+        data-cat="{{ form.instance.category|default_if_none:'' }}"
+        data-op="{{ form.instance.operation|default_if_none:'' }}">
     {% csrf_token %}
 
-    <div class="form-row">
-      {{ form.category.label_tag }} {{ form.category }}
+    <div class="chips" style="display:flex; gap:.5rem; align-items:center; margin:.5rem 0;">
+      <span class="chip" style="border:1px solid #ccc; padding:.2rem .5rem; border-radius:.5rem;">
+        {{ form.instance.category|default:form.category.value }}
+      </span>
+      {% if form.fields.operation %}
+      <span class="chip" style="border:1px solid #ccc; padding:.2rem .5rem; border-radius:.5rem;">
+        {{ form.instance.operation|default:form.operation.value }}
+      </span>
+      {% endif %}
+      <a href="#" id="toggle-type">Изменить</a>
     </div>
-    {% if form.fields.operation %}
-      <div class="form-row">
-        {{ form.operation.label_tag }} {{ form.operation }}
-      </div>
-    {% endif %}
+
+    <div id="type-selects" style="display:none; margin-bottom:.5rem;">
+      <div class="form-row">{{ form.category.label_tag }} {{ form.category }}</div>
+      {% if form.fields.operation %}
+      <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
+      {% endif %}
+    </div>
 
     <section class="group">
       <h3>Основное</h3>
@@ -363,4 +375,13 @@
       {% endfor %}
     </div>
   {% endif %}
+  <script>
+  document.addEventListener('DOMContentLoaded',function(){
+    var a=document.getElementById('toggle-type');
+    var box=document.getElementById('type-selects');
+    if(a&&box){
+      a.addEventListener('click',function(e){e.preventDefault(); box.style.display = box.style.display ? '' : 'none';});
+    }
+  });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- hide the category/operation selects by default while keeping current values visible as chips
- expose category/operation values to scripts via form data attributes and toggle-able block
- drive conditional section visibility using either select changes or the stored dataset values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0ff565b908320bce477fc5c6f36b3