### PR TITLE
Create flow: no drafts

### DIFF
--- a/core/templates/core/panel_new_step1.html
+++ b/core/templates/core/panel_new_step1.html
@@ -7,4 +7,5 @@
     <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
     <button type="submit">Далее</button>
   </form>
+  <p class="form-hint">Запись будет создана только после нажатия «Сохранить» на следующем шаге.</p>
 {% endblock %}

--- a/realcrm/urls.py
+++ b/realcrm/urls.py
@@ -7,6 +7,7 @@ from core import views as core_views
 urlpatterns = [
     path("panel/", core_views.panel_list, name="panel_list"),
     path("panel/new/", core_views.panel_new, name="panel_new"),
+    path("panel/create/", core_views.panel_create, name="panel_create"),
     path("panel/edit/<int:pk>/", core_views.panel_edit, name="panel_edit"),
     path("panel/edit/<int:pk>/add-photo/", core_views.panel_add_photo, name="panel_add_photo"),
     path("panel/photo/<int:photo_id>/delete/", core_views.panel_delete_photo, name="panel_delete_photo"),


### PR DESCRIPTION
## Summary
- update the step 1 panel form to redirect to the creation step without creating a draft
- add a dedicated create view that saves the property only after the final submission
- document the delayed creation behaviour in the initial step template and wire the new route

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e108a6603083208f468cc8a764c3f9