### PR TITLE
UI: archive + export toggles + list filter

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -24,6 +24,7 @@ class PropertyForm(forms.ModelForm):
         fields = [
             "external_id","category",
             "title","description",
+            "export_to_cian","export_to_domclick",
             "address","lat","lng","cadastral_number",
             "phone_country","phone_number","phone_number2",
             "layout_photo_url","object_tour_url",

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -29,6 +29,12 @@
     </div>
 
     <section class="group">
+      <h3>Экспорт</h3>
+      <div class="form-row">{{ form.export_to_cian.label_tag }} {{ form.export_to_cian }}</div>
+      <div class="form-row">{{ form.export_to_domclick.label_tag }} {{ form.export_to_domclick }}</div>
+    </section>
+
+    <section class="group">
       <h3>Основное</h3>
       <div class="form-row">
         {{ form.external_id.label_tag }}

--- a/core/templates/core/panel_list.html
+++ b/core/templates/core/panel_list.html
@@ -3,6 +3,14 @@
 {% block content %}
   <h1>Объекты</h1>
 
+  <p style="margin-bottom:1rem;">
+    <a href="/panel/">Активные</a>
+    |
+    <a href="/panel/?show=archived">Архив</a>
+    |
+    <a href="/panel/?show=all">Все</a>
+  </p>
+
   <form method="get" action="/panel/">
     <input type="text" name="q" value="{{ q }}" placeholder="Поиск: заголовок / город / ExternalId">
     <button type="submit">Искать</button>
@@ -37,7 +45,14 @@
           <td>{{ p.title }}</td>
           <td>{{ p.city }}</td>
           <td><span class="muted">{{ p.updated_at }}</span></td>
-          <td><a href="/panel/edit/{{ p.pk }}/">Открыть</a></td>
+          <td style="display:flex; gap:.5rem;">
+            <a href="/panel/edit/{{ p.pk }}/">Открыть</a>
+            {% if p.status == "active" %}
+              <a href="/panel/archive/{{ p.pk }}/">В архив</a>
+            {% elif p.status == "archived" %}
+              <a href="/panel/restore/{{ p.pk }}/">Вернуть</a>
+            {% endif %}
+          </td>
         </tr>
       {% empty %}
         <tr><td colspan="5">Пока нет объектов</td></tr>

--- a/realcrm/urls.py
+++ b/realcrm/urls.py
@@ -13,4 +13,6 @@ urlpatterns = [
     path("panel/photo/<int:photo_id>/delete/", core_views.panel_delete_photo, name="panel_delete_photo"),
     path("panel/photo/<int:photo_id>/make-main/", core_views.panel_toggle_main, name="panel_toggle_main"),
     path("panel/generate-feeds/", core_views.panel_generate_feeds, name="panel_generate_feeds"),
+    path("panel/archive/<int:pk>/", core_views.panel_archive, name="panel_archive"),
+    path("panel/restore/<int:pk>/", core_views.panel_restore, name="panel_restore"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- filter panel list by status with active, archived, and all toggles
- add archive/restore actions for properties and export checkboxes in the editor
- expose new archive routes and include export flags in the property form

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68e1122e6f2c8320a2ed08e479a74da4