### PR TITLE
UI: restore house fields in form and template

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -41,9 +41,9 @@ class PropertyForm(forms.ModelForm):
 
             "house_type",
             "land_area","land_area_unit","permitted_land_use","is_land_with_contract","land_category","land_type",
-            "heating_type","has_terrace","has_cellar",
+            "heating_type","ceiling_height","has_terrace","has_cellar","power","has_parking","parking_places",
 
-            "commercial_type","is_rent_by_parts","rent_by_parts_desc","ceiling_height","power","parking_places","has_parking",
+            "commercial_type","is_rent_by_parts","rent_by_parts_desc",
 
             "furnishing_details","has_internet","has_furniture","has_kitchen_furniture","has_tv","has_washer","has_conditioner",
             "has_refrigerator","has_dishwasher","has_shower","has_phone","has_ramp","has_bathtub",

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -279,7 +279,7 @@
 
     <section class="group" data-cat="house">
       <h3>Дом</h3>
-      <div class="form-row">{{ form.house_type.label_tag }} {{ form.house_type }}</div>
+      {% if form.fields.house_type %}<div class="form-row">{{ form.house_type.label_tag }} {{ form.house_type }}</div>{% endif %}
       <div class="form-row">{{ form.land_area.label_tag }} {{ form.land_area }}</div>
       <div class="form-row">{{ form.land_area_unit.label_tag }} {{ form.land_area_unit }}</div>
       <div class="form-row">{{ form.permitted_land_use.label_tag }} {{ form.permitted_land_use }}</div>


### PR DESCRIPTION
## Summary
- include the house-specific land, heating, and parking fields in `PropertyForm`
- render those house-related inputs in the "Дом" section of the panel edit template with a conditional house type input

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e11d9792588320b41eea6c1a4d8f21