### PR TITLE
Wizard: choose type, then show relevant sections (no drafts)

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -79,15 +79,12 @@ class PhotoForm(forms.ModelForm):
 
 
 class NewObjectStep1Form(forms.Form):
-    # choices из модели, если есть; иначе — дефолты
     CATEGORY_CHOICES = getattr(Property, "CATEGORY_CHOICES", [
-        ("flat", "Квартира"), ("room", "Комната"),
-        ("house", "Дом/коттедж"), ("commercial", "Коммерческая"),
+        ("flat","Квартира"), ("room","Комната"),
+        ("house","Дом/коттедж"), ("commercial","Коммерческая"), ("land","Земельный участок"),
     ])
-    # поле operation может отсутствовать в модели — форму всё равно показываем
     OPERATION_CHOICES = getattr(Property, "OPERATION_CHOICES", [
-        ("sale", "Продажа"), ("rent", "Аренда"),
+        ("sale","Продажа"), ("rent","Аренда"),
     ])
-
     category  = forms.ChoiceField(choices=CATEGORY_CHOICES, label="Тип объекта")
     operation = forms.ChoiceField(choices=OPERATION_CHOICES, label="Тип сделки", required=False)

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -56,35 +56,36 @@
     {% block content %}{% endblock %}
   </main>
   <script>
-  document.addEventListener('DOMContentLoaded', function(){
-    function byId(id){ return document.getElementById(id); }
-    function getCatOp(){
-      var form = document.querySelector('form[data-cat]');
-      var catData = form ? (form.getAttribute('data-cat') || '').trim() : '';
-      var opData  = form ? (form.getAttribute('data-op')  || '').trim() : '';
-      var catSel = byId('id_category');
-      var opSel  = byId('id_operation');
-      return {
-        cat: catSel ? (catSel.value||'').trim() : catData,
-        op:  opSel  ? (opSel.value||'').trim()  : opData
-      };
-    }
-    function updateGroups(){
-      var cur = getCatOp();
-      document.querySelectorAll('.group').forEach(function(sec){
-        var cats = (sec.dataset.cat||'').split(',').map(function(s){return s.trim();}).filter(Boolean);
-        var ops  = (sec.dataset.op ||'').split(',').map(function(s){return s.trim();}).filter(Boolean);
-        var catOK = !cats.length || (cur.cat && cats.includes(cur.cat));
-        var opOK  = !ops.length  || (cur.op  && ops.includes(cur.op));
-        sec.style.display = (catOK && opOK) ? '' : 'none';
-      });
-    }
-    ['id_category','id_operation'].forEach(function(id){
-      var el = byId(id);
-      if (el) el.addEventListener('change', updateGroups);
+document.addEventListener('DOMContentLoaded', function(){
+  function byId(id){ return document.getElementById(id); }
+  function getCatOp(){
+    var form = document.querySelector('form[data-cat]');
+    var catData = form ? (form.getAttribute('data-cat')||'').trim() : '';
+    var opData  = form ? (form.getAttribute('data-op') ||'').trim() : '';
+    var catSel  = byId('id_category');
+    var opSel   = byId('id_operation');
+    var catInit = byId('initial_category');
+    var opInit  = byId('initial_operation');
+    var cat = (catSel && catSel.value) ? catSel.value.trim() : (catData || (catInit ? catInit.value.trim() : ''));
+    var op  = (opSel  && opSel.value)  ? opSel.value.trim()  : (opData  || (opInit  ? opInit.value.trim()  : ''));
+    return {cat:cat, op:op};
+  }
+  function updateGroups(){
+    var cur = getCatOp();
+    document.querySelectorAll('.group').forEach(function(sec){
+      var cats = (sec.dataset.cat||'').split(',').map(s=>s.trim()).filter(Boolean);
+      var ops  = (sec.dataset.op ||'').split(',').map(s=>s.trim()).filter(Boolean);
+      var catOK = !cats.length || (cur.cat && cats.includes(cur.cat));
+      var opOK  = !ops.length  || (cur.op  && ops.includes(cur.op));
+      sec.style.display = (catOK && opOK) ? '' : 'none';
     });
-    updateGroups();
+  }
+  ['id_category','id_operation'].forEach(function(id){
+    var el = byId(id);
+    if (el) el.addEventListener('change', updateGroups);
   });
+  updateGroups();
+});
   </script>
 </body>
 </html>

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -5,28 +5,15 @@
   <h1>{{ prop|default:"Новый объект" }}</h1>
 
   <form method="post"
-        data-cat="{{ form.instance.category|default_if_none:'' }}"
-        data-op="{{ form.instance.operation|default_if_none:'' }}">
+        data-cat="{{ form.instance.category|default_if_none:''|default:initial_vals.category }}"
+        data-op="{{ form.instance.operation|default_if_none:''|default:initial_vals.operation }}">
     {% csrf_token %}
-
-    <div class="chips" style="display:flex; gap:.5rem; align-items:center; margin:.5rem 0;">
-      <span class="chip" style="border:1px solid #ccc; padding:.2rem .5rem; border-radius:.5rem;">
-        {{ form.instance.category|default:form.category.value }}
-      </span>
-      {% if form.fields.operation %}
-      <span class="chip" style="border:1px solid #ccc; padding:.2rem .5rem; border-radius:.5rem;">
-        {{ form.instance.operation|default:form.operation.value }}
-      </span>
-      {% endif %}
-      <a href="#" id="toggle-type">Изменить</a>
-    </div>
-
-    <div id="type-selects" style="display:none; margin-bottom:.5rem;">
-      <div class="form-row">{{ form.category.label_tag }} {{ form.category }}</div>
-      {% if form.fields.operation %}
-      <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
-      {% endif %}
-    </div>
+    <input type="hidden" id="initial_category" value="{{ initial_vals.category|default:'' }}">
+    <input type="hidden" id="initial_operation" value="{{ initial_vals.operation|default:'' }}">
+    <div class="form-row">{{ form.category.label_tag }} {{ form.category }}</div>
+    {% if form.fields.operation %}
+    <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
+    {% endif %}
 
     <section class="group">
       <h3>Экспорт</h3>

--- a/core/templates/core/panel_new_step1.html
+++ b/core/templates/core/panel_new_step1.html
@@ -3,9 +3,10 @@
   <h1>Новый объект</h1>
   <form method="post">{% csrf_token %}
     <div class="form-row">{{ form.category.label_tag }} {{ form.category }}</div>
-    {# показываем поле сделки, даже если его потом некуда сохранять — это пригодится позже #}
     <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
     <button type="submit">Далее</button>
   </form>
-  <p class="form-hint">Запись будет создана только после нажатия «Сохранить» на следующем шаге.</p>
+  <p style="font-size:.9em;color:#666;margin-top:.5rem;">
+    Запись будет создана только после нажатия «Сохранить» на следующем шаге.
+  </p>
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -250,39 +250,28 @@ def panel_new(request):
     if request.method == "POST":
         form = NewObjectStep1Form(request.POST)
         if form.is_valid():
-            cat = form.cleaned_data.get("category") or ""
-            op = form.cleaned_data.get("operation") or ""
+            cat = form.cleaned_data.get("category","")
+            op  = form.cleaned_data.get("operation","")
             return redirect(f"/panel/create/?category={cat}&operation={op}")
     else:
         form = NewObjectStep1Form()
-
     return render(request, "core/panel_new_step1.html", {"form": form})
 
 
 def panel_create(request):
     initial = {
-        "category": request.GET.get("category", ""),
-        "operation": request.GET.get("operation", ""),
+        "category": request.GET.get("category",""),
+        "operation": request.GET.get("operation",""),
     }
     if request.method == "POST":
         form = PropertyForm(request.POST)
-        _enable_choice_fields(form, ["category", "operation"])
         if form.is_valid():
             prop = form.save()
             return redirect(f"/panel/edit/{prop.pk}/")
     else:
         form = PropertyForm(initial=initial)
-        _enable_choice_fields(form, ["category", "operation"])
-
-    return render(
-        request,
-        "core/panel_edit.html",
-        {
-            "form": form,
-            "prop": None,
-            "photos": [],
-        },
-    )
+    # ВАЖНО: пробрасываем initial_vals в шаблон, чтобы секции включались сразу
+    return render(request, "core/panel_edit.html", {"form": form, "prop": None, "photos": [], "initial_vals": initial})
 
 def panel_edit(request, pk):
     """
@@ -300,7 +289,11 @@ def panel_edit(request, pk):
         form = PropertyForm(instance=prop)
         _enable_choice_fields(form, ["category", "operation"])
     # пока без фактических фото — отдадим пустой список для шаблона
-    return render(request, "core/panel_edit.html", {"form": form, "prop": prop, "photos": []})
+    return render(
+        request,
+        "core/panel_edit.html",
+        {"form": form, "prop": prop, "photos": [], "initial_vals": {"category": "", "operation": ""}},
+    )
 
 def panel_add_photo(request, pk):
     # TODO: заменить на реальную загрузку (URL или FileField)


### PR DESCRIPTION
## Summary
- add a dedicated step-1 form to select category and operation without creating drafts
- wire `/panel/new/` to redirect into `/panel/create/` with initial values and render the edit view with initial metadata
- ensure the edit template exposes selection data to JavaScript and upgrade section toggling logic for robustness

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e1218f593c8320a2eb86f5bf8cf591