### PR TITLE
Add section heading for category and operation fields

### DIFF
--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -10,10 +10,13 @@
     {% csrf_token %}
     <input type="hidden" id="initial_category" value="{{ initial_vals.category|default:'' }}">
     <input type="hidden" id="initial_operation" value="{{ initial_vals.operation|default:'' }}">
-    <div class="form-row">{{ form.category.label_tag }} {{ form.category }}</div>
-    {% if form.fields.operation %}
-    <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
-    {% endif %}
+    <section class="group">
+      <h3>Тип и сделка</h3>
+      <div class="form-row">{{ form.category.label_tag }} {{ form.category }}</div>
+      {% if form.fields.operation %}
+      <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
+      {% endif %}
+    </section>
 
     <section class="group">
       <h3>Экспорт</h3>


### PR DESCRIPTION
## Summary
- wrap the category and operation form rows in a dedicated "Тип и сделка" section on the panel edit form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1449ac3d883208ac6c7912186f42b