### PR TITLE
feat: normalize object type workflow, per-type UI, safe create, export mapping

### DIFF
--- a/core/cian.py
+++ b/core/cian.py
@@ -1,66 +1,110 @@
 from typing import Optional
 
-# Минимальный набор соответствий из спецификации ЦИАН:
-# https://www.cian.ru/xml_import/doc/  → в разделах видно строки вида flatSale/flatRent/roomSale/... (Категория)  # noqa
 
-CIAN_CATEGORY = {
-    # Квартиры/комнаты
-    ("flat",  "sale"): "flatSale",
-    ("flat",  "rent"): "flatRent",
-    ("room",  "sale"): "roomSale",
-    ("room",  "rent"): "roomRent",
-
-    # Загородная — различаем подтип
-    ("house", "sale", "house"):     "houseSale",
-    ("house", "rent", "house"):     "houseRent",
-    ("house", "sale", "cottage"):   "cottageSale",
-    ("house", "rent", "cottage"):   "cottageRent",
-    ("house", "sale", "townhouse"): "townhouseSale",
-    ("house", "rent", "townhouse"): "townhouseRent",
-    ("house", "sale", "share"):     "houseShareSale",
-    ("house", "rent", "share"):     "houseShareRent",
-    # Если поставили подтип "dacha", кладём как дом (IsDacha отдадим отдельным тегом)
-    ("house", "sale", "dacha"):     "houseSale",
-    ("house", "rent", "dacha"):     "houseRent",
-
-    # Земля
-    ("land",  "sale"): "landSale",
-    ("land",  "rent"): "landRent",
-
-    # Коммерция — базовые примеры; при нужде расширим
-    ("commercial", "sale", "office"):        "officeSale",
-    ("commercial", "rent", "office"):        "officeRent",
-    ("commercial", "sale", "building"):      "buildingSale",
-    ("commercial", "rent", "building"):      "buildingRent",
-    ("commercial", "sale", "garage"):        "garageSale",
-    ("commercial", "rent", "garage"):        "garageRent",
-    ("commercial", "sale", "commercialland"): "commercialLandSale",
-    ("commercial", "rent", "commercialland"): "commercialLandRent",
-    ("commercial", "sale", "industry"):      "industrySale",
-    ("commercial", "rent", "industry"):      "industryRent",
-}
+def _clean(value: Optional[str]) -> str:
+    return (value or "").strip().lower()
 
 
-def resolve_cian_category(obj) -> Optional[str]:
-    """
-    Возвращает строку Category по полям:
-    - obj.category: flat/room/house/commercial/land
-    - obj.operation: sale/rent
-    - подтип (если требуется): house_type / commercial_type / land_type
-    """
+def _house_base(subtype: str) -> str:
+    if not subtype:
+        return "house"
+    if subtype in {"cottage", "kothedge"}:
+        return "cottage"
+    if subtype in {"townhouse", "таунхаус"}:
+        return "townhouse"
+    if "share" in subtype or "доля" in subtype:
+        return "houseShare"
+    if subtype in {"dacha", "дача"}:
+        return "house"
+    return "house"
 
-    cat = (getattr(obj, "category", None) or "").strip().lower() or None
-    op = (getattr(obj, "operation", None) or "").strip().lower() or None
+
+def _commercial_base(subtype: str) -> str:
+    if not subtype:
+        return "office"
+    mapping = {
+        "office": "office",
+        "retail": "shoppingArea",
+        "shop": "shoppingArea",
+        "store": "shoppingArea",
+        "warehouse": "warehouse",
+        "production": "industry",
+        "industry": "industry",
+        "free_purpose": "freeAppointmentObject",
+        "freepurpose": "freeAppointmentObject",
+        "psn": "freeAppointmentObject",
+        "building": "building",
+        "garage": "garage",
+        "commercial_land": "commercialLand",
+        "commercialland": "commercialLand",
+        "land": "commercialLand",
+    }
+    for key, value in mapping.items():
+        if key in subtype:
+            return value
+    if "office" in subtype:
+        return "office"
+    return "office"
+
+
+def build_cian_category(category: Optional[str], operation: Optional[str], subtype: Optional[str]) -> str:
+    cat = _clean(category)
+    op = _clean(operation)
+    sub = _clean(subtype)
+
     if not cat or not op:
-        return None
+        return ""
+
+    if cat == "flat":
+        if op == "sale":
+            return "flatSale"
+        if op == "rent_long":
+            return "flatRent"
+        if op == "rent_daily":
+            return "dailyFlatRent"
+        return ""
+
+    if cat == "room":
+        if op == "sale":
+            return "roomSale"
+        if op == "rent_long":
+            return "roomRent"
+        if op == "rent_daily":
+            return "dailyRoomRent"
+        return ""
 
     if cat == "house":
-        subtype = (getattr(obj, "house_type", None) or "house").strip().lower()
-        return CIAN_CATEGORY.get((cat, op, subtype))
+        base = _house_base(sub)
+        if op == "sale":
+            return f"{base}Sale"
+        if op == "rent_long":
+            return f"{base}Rent"
+        if op == "rent_daily":
+            return "dailyHouseRent"
+        return ""
+
     if cat == "commercial":
-        csub = (getattr(obj, "commercial_type", None) or "office").strip().lower()
-        return CIAN_CATEGORY.get((cat, op, csub))
+        base = _commercial_base(sub)
+        if op == "sale":
+            return f"{base}Sale"
+        if op == "rent_long":
+            return f"{base}Rent"
+        if op == "rent_daily":
+            return f"{base}Rent"
+        return ""
+
     if cat == "land":
-        return CIAN_CATEGORY.get((cat, op))
-    # flat / room
-    return CIAN_CATEGORY.get((cat, op))
+        if op == "sale":
+            return "landSale"
+        if op == "rent_long":
+            return "landRent"
+        return ""
+
+    if cat == "garage":
+        if op == "sale":
+            return "garageSale"
+        if op in {"rent_long", "rent_daily"}:
+            return "garageRent"
+        return ""
+
+    return ""

--- a/core/forms.py
+++ b/core/forms.py
@@ -24,8 +24,18 @@ class PropertyForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Убираем легаси-поля с комбинированными категориями (mega-select)
+        legacy_category_fields = (
+            "category_combined",
+            "type_combined",
+            "legacy_category",
+            "legacy_category_combined",
+        )
+        for legacy in legacy_category_fields:
+            self.fields.pop(legacy, None)
+
         # Гарантируем, что базовые селекты присутствуют, если есть в модели
-        for base in ("category", "operation"):
+        for base in ("category", "operation", "subtype"):
             if hasattr(self._meta.model, base) and base not in self.fields:
                 try:
                     model_field = self._meta.model._meta.get_field(base)
@@ -152,11 +162,17 @@ class PhotoForm(forms.ModelForm):
 
 class NewObjectStep1Form(forms.Form):
     CATEGORY_CHOICES = getattr(Property, "CATEGORY_CHOICES", [
-        ("flat","Квартира"), ("room","Комната"),
-        ("house","Дом/коттедж"), ("commercial","Коммерческая"), ("land","Земельный участок"),
+        ("house", "Дом"),
+        ("flat", "Квартира"),
+        ("room", "Комната"),
+        ("commercial", "Коммерция"),
+        ("land", "Земля"),
+        ("garage", "Гараж"),
     ])
     OPERATION_CHOICES = getattr(Property, "OPERATION_CHOICES", [
-        ("sale","Продажа"), ("rent","Аренда"),
+        ("sale", "Продажа"),
+        ("rent_long", "Аренда"),
+        ("rent_daily", "Посуточно"),
     ])
     category  = forms.ChoiceField(choices=CATEGORY_CHOICES, label="Тип объекта")
     operation = forms.ChoiceField(choices=OPERATION_CHOICES, label="Тип сделки", required=False)

--- a/core/static/core/form.js
+++ b/core/static/core/form.js
@@ -1,0 +1,63 @@
+(function () {
+  function storeInitialDisabled(control) {
+    if (control.dataset.initialDisabled === undefined) {
+      control.dataset.initialDisabled = control.disabled ? 'true' : 'false';
+    }
+  }
+
+  function setDisabled(section, shouldDisable) {
+    var controls = section.querySelectorAll('input, select, textarea');
+    controls.forEach(function (control) {
+      storeInitialDisabled(control);
+      if (shouldDisable) {
+        control.disabled = true;
+      } else if (control.dataset.initialDisabled === 'true') {
+        control.disabled = true;
+      } else {
+        control.disabled = false;
+      }
+    });
+  }
+
+  function normalizeType(type) {
+    return (type || '').trim();
+  }
+
+  function showSection(type) {
+    var target = normalizeType(type);
+    var sections = document.querySelectorAll('[data-section]');
+    sections.forEach(function (section) {
+      var dataset = (section.dataset.section || '').split(',').map(function (value) {
+        return value.trim();
+      }).filter(Boolean);
+      var match = target && dataset.includes(target);
+      if (match) {
+        section.hidden = false;
+        setDisabled(section, false);
+      } else {
+        section.hidden = true;
+        setDisabled(section, true);
+      }
+    });
+  }
+
+  function currentCategory() {
+    var categoryField = document.getElementById('id_category');
+    return categoryField ? categoryField.value : '';
+  }
+
+  function handleChange() {
+    showSection(currentCategory());
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var categoryField = document.getElementById('id_category');
+    var subtypeField = document.getElementById('id_subtype');
+    handleChange();
+    [categoryField, subtypeField].forEach(function (field) {
+      if (field) {
+        field.addEventListener('change', handleChange);
+      }
+    });
+  });
+})();

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -21,6 +21,11 @@
     .group:first-of-type { border-top: none; padding-top: 0; }
     .group > h3 { margin-bottom: .6rem; }
     label { margin-bottom:.2rem; font-weight:600; font-size:.9em; }
+    .badges { display:flex; gap:.35rem; flex-wrap:wrap; margin-top:.35rem; }
+    .badge { display:inline-flex; align-items:center; padding:.15rem .5rem; border-radius:.45rem; font-size:.75rem; font-weight:600; }
+    .badge-cian { background:#dff4df; color:#1c6724; }
+    .badge-domklik { background:#dce8ff; color:#1f4f93; }
+    .badge-archived { background:#ececec; color:#555; }
     button,
     .button,
     input[type="button"],
@@ -58,37 +63,6 @@
     </nav>
     {% block content %}{% endblock %}
   </main>
-  <script>
-document.addEventListener('DOMContentLoaded', function(){
-  function byId(id){ return document.getElementById(id); }
-  function getCatOp(){
-    var form = document.querySelector('form[data-cat]');
-    var catData = form ? (form.getAttribute('data-cat')||'').trim() : '';
-    var opData  = form ? (form.getAttribute('data-op') ||'').trim() : '';
-    var catSel  = byId('id_category');
-    var opSel   = byId('id_operation');
-    var catInit = byId('initial_category');
-    var opInit  = byId('initial_operation');
-    var cat = (catSel && catSel.value) ? catSel.value.trim() : (catData || (catInit ? catInit.value.trim() : ''));
-    var op  = (opSel  && opSel.value)  ? opSel.value.trim()  : (opData  || (opInit  ? opInit.value.trim()  : ''));
-    return {cat:cat, op:op};
-  }
-  function updateGroups(){
-    var cur = getCatOp();
-    document.querySelectorAll('.group').forEach(function(sec){
-      var cats = (sec.dataset.cat||'').split(',').map(s=>s.trim()).filter(Boolean);
-      var ops  = (sec.dataset.op ||'').split(',').map(s=>s.trim()).filter(Boolean);
-      var catOK = !cats.length || (cur.cat && cats.includes(cur.cat));
-      var opOK  = !ops.length  || (cur.op  && ops.includes(cur.op));
-      sec.style.display = (catOK && opOK) ? '' : 'none';
-    });
-  }
-  ['id_category','id_operation'].forEach(function(id){
-    var el = byId(id);
-    if (el) el.addEventListener('change', updateGroups);
-  });
-  updateGroups();
-});
-  </script>
+  {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -1,27 +1,24 @@
 {% extends "base.html" %}
+{% load static %}
 {% block title %}{{ prop|default:"Новый объект" }} — Мини-CRM{% endblock %}
 {% block content %}
   <a href="/panel/">&larr; к списку</a>
   <h1>{{ prop|default:"Новый объект" }}</h1>
 
-  <form method="post"
-        data-cat="{{ form.instance.category|default_if_none:''|default:initial_vals.category }}"
-        data-op="{{ form.instance.operation|default_if_none:''|default:initial_vals.operation }}">
+  <form method="post">
     {% csrf_token %}
-    <input type="hidden" id="initial_category" value="{{ initial_vals.category|default:'' }}">
-    <input type="hidden" id="initial_operation" value="{{ initial_vals.operation|default:'' }}">
     <section class="group">
       <h3>Тип и сделка</h3>
       <div class="form-row">{{ form.category.label_tag }} {{ form.category }}</div>
-      {% if form.fields.operation %}
       <div class="form-row">{{ form.operation.label_tag }} {{ form.operation }}</div>
-      {% endif %}
+      <div class="form-row">{{ form.subtype.label_tag }} {{ form.subtype }}</div>
     </section>
 
     <section class="group">
       <h3>Экспорт</h3>
-      <div class="form-row">{{ form.export_to_cian.label_tag }} {{ form.export_to_cian }}</div>
-      <div class="form-row">{{ form.export_to_domclick.label_tag }} {{ form.export_to_domclick }}</div>
+      <div class="form-row"><label>{{ form.export_to_cian }} {{ form.export_to_cian.label }}</label></div>
+      <div class="form-row"><label>{{ form.export_to_domklik }} {{ form.export_to_domklik.label }}</label></div>
+      <div class="form-row"><label>{{ form.is_archived }} {{ form.is_archived.label }}</label></div>
     </section>
 
     <!-- Общие поля (видны всегда) -->
@@ -55,20 +52,6 @@
           {{ form.min_rent_term_months.label_tag }}
           {{ form.min_rent_term_months }}
         </div>
-      </div>
-    </section>
-
-    <!-- Площади (видны всегда, чтобы "Общая площадь" была у любых типов) -->
-    <section class="group">
-      <h3>Площади</h3>
-      <div class="form-row">
-        {{ form.total_area.label_tag }} {{ form.total_area }}
-      </div>
-      <div class="form-row">
-        {{ form.living_area.label_tag }} {{ form.living_area }}
-      </div>
-      <div class="form-row">
-        {{ form.kitchen_area.label_tag }} {{ form.kitchen_area }}
       </div>
     </section>
 
@@ -156,140 +139,541 @@
       </div>
     </section>
 
-    <!-- Жилые характеристики (квартира/дом/комната) -->
-    <section class="group" data-cat="flat,house,room">
-      <h3>Характеристики жилья</h3>
-      {% if form.fields.flat_type %}<div class="form-row" data-cat="flat">{{ form.flat_type.label_tag }} {{ form.flat_type }}</div>{% endif %}
-      {% if form.fields.room_type_ext %}<div class="form-row" data-cat="room">{{ form.room_type_ext.label_tag }} {{ form.room_type_ext }}</div>{% endif %}
-      <div class="form-row">{{ form.rooms.label_tag }} {{ form.rooms }}</div>
-      <div class="form-row">{{ form.floor_number.label_tag }} {{ form.floor_number }}</div>
+    <div class="group" data-section="house">
+      <h3>Параметры дома</h3>
+      {% if form.fields.house_type %}
       <div class="form-row">
-        {{ form.room_type.label_tag }}
-        {{ form.room_type }}
+        <label for="{{ form.house_type.id_for_label }}_house">{{ form.house_type.label }}</label>
+        {{ form.house_type.as_widget(attrs={'id': form.house_type.id_for_label|add:'_house'}) }}
+        {{ form.house_type.errors }}
       </div>
+      {% endif %}
+      {% with field=form.total_area %}
       <div class="form-row">
-        {{ form.flat_rooms_count.label_tag }}
-        {{ form.flat_rooms_count }}
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
       </div>
+      {% endwith %}
+      {% with field=form.living_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.kitchen_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.land_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.land_area_unit %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.permitted_land_use %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.is_land_with_contract %}
+      <div class="form-row">
+        <label>
+          {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }} {{ field.label }}
+        </label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.land_category %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.heating_type %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.has_terrace %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.has_cellar %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.rooms %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.repair_type %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.separate_wcs_count %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.combined_wcs_count %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.ceiling_height %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.power %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.has_parking %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.parking_places %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_house">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_house'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+    </div>
+
+    <div class="group" data-section="flat">
+      <h3>Квартира</h3>
+      {% if form.fields.flat_type %}
+      <div class="form-row">
+        <label for="{{ form.flat_type.id_for_label }}_flat">{{ form.flat_type.label }}</label>
+        {{ form.flat_type.as_widget(attrs={'id': form.flat_type.id_for_label|add:'_flat'}) }}
+        {{ form.flat_type.errors }}
+      </div>
+      {% endif %}
+      {% with field=form.total_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.living_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.kitchen_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.rooms %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.floor_number %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.room_type %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.flat_rooms_count %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
       <div class="form-row row-2">
+        {% with field=form.loggias_count %}
         <div class="form-row">
-          {{ form.loggias_count.label_tag }}
-          {{ form.loggias_count }}
+          <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+          {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+          {{ field.errors }}
         </div>
+        {% endwith %}
+        {% with field=form.balconies_count %}
         <div class="form-row">
-          {{ form.balconies_count.label_tag }}
-          {{ form.balconies_count }}
+          <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+          {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+          {{ field.errors }}
         </div>
+        {% endwith %}
       </div>
+      {% with field=form.windows_view_type %}
       <div class="form-row">
-        {{ form.windows_view_type.label_tag }}
-        {{ form.windows_view_type }}
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
       </div>
+      {% endwith %}
       <div class="form-row row-2">
+        {% with field=form.separate_wcs_count %}
         <div class="form-row">
-          {{ form.separate_wcs_count.label_tag }}
-          {{ form.separate_wcs_count }}
+          <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+          {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+          {{ field.errors }}
         </div>
+        {% endwith %}
+        {% with field=form.combined_wcs_count %}
         <div class="form-row">
-          {{ form.combined_wcs_count.label_tag }}
-          {{ form.combined_wcs_count }}
+          <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+          {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+          {{ field.errors }}
         </div>
+        {% endwith %}
+      </div>
+      {% with field=form.repair_type %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_flat">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.is_euro_flat %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.is_apartments %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.is_penthouse %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_flat'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      <div class="form-row">
+        <label for="{{ form.jk_id.id_for_label }}_flat">{{ form.jk_id.label }}</label>
+        {{ form.jk_id.as_widget(attrs={'id': form.jk_id.id_for_label|add:'_flat'}) }}
+        {{ form.jk_id.errors }}
       </div>
       <div class="form-row">
-        {{ form.repair_type.label_tag }}
-        {{ form.repair_type }}
+        <label for="{{ form.jk_name.id_for_label }}_flat">{{ form.jk_name.label }}</label>
+        {{ form.jk_name.as_widget(attrs={'id': form.jk_name.id_for_label|add:'_flat'}) }}
+        {{ form.jk_name.errors }}
       </div>
       <div class="form-row">
-        <label>{{ form.is_euro_flat }} {{ form.is_euro_flat.label }}</label>
+        <label for="{{ form.house_id.id_for_label }}_flat">{{ form.house_id.label }}</label>
+        {{ form.house_id.as_widget(attrs={'id': form.house_id.id_for_label|add:'_flat'}) }}
+        {{ form.house_id.errors }}
       </div>
       <div class="form-row">
-        <label>{{ form.is_apartments }} {{ form.is_apartments.label }}</label>
+        <label for="{{ form.house_name.id_for_label }}_flat">{{ form.house_name.label }}</label>
+        {{ form.house_name.as_widget(attrs={'id': form.house_name.id_for_label|add:'_flat'}) }}
+        {{ form.house_name.errors }}
       </div>
       <div class="form-row">
-        <label>{{ form.is_penthouse }} {{ form.is_penthouse.label }}</label>
+        <label for="{{ form.flat_number.id_for_label }}_flat">{{ form.flat_number.label }}</label>
+        {{ form.flat_number.as_widget(attrs={'id': form.flat_number.id_for_label|add:'_flat'}) }}
+        {{ form.flat_number.errors }}
       </div>
-    </section>
+      <div class="form-row">
+        <label for="{{ form.section_number.id_for_label }}_flat">{{ form.section_number.label }}</label>
+        {{ form.section_number.as_widget(attrs={'id': form.section_number.id_for_label|add:'_flat'}) }}
+        {{ form.section_number.errors }}
+      </div>
+    </div>
 
-    <section class="group" data-cat="flat,room">
-      <h3>ЖК и корпус</h3>
+    <div class="group" data-section="room">
+      <h3>Комната</h3>
+      {% if form.fields.room_type_ext %}
       <div class="form-row">
-        {{ form.jk_id.label_tag }}
-        {{ form.jk_id }}
+        <label for="{{ form.room_type_ext.id_for_label }}_room">{{ form.room_type_ext.label }}</label>
+        {{ form.room_type_ext.as_widget(attrs={'id': form.room_type_ext.id_for_label|add:'_room'}) }}
+        {{ form.room_type_ext.errors }}
+      </div>
+      {% endif %}
+      {% with field=form.total_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_room">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_room'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.living_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_room">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_room'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.rooms %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_room">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_room'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.floor_number %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_room">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_room'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.room_type %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_room">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_room'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      <div class="form-row row-2">
+        {% with field=form.separate_wcs_count %}
+        <div class="form-row">
+          <label for="{{ field.id_for_label }}_room">{{ field.label }}</label>
+          {{ field.as_widget(attrs={'id': field.id_for_label|add:'_room'}) }}
+          {{ field.errors }}
+        </div>
+        {% endwith %}
+        {% with field=form.combined_wcs_count %}
+        <div class="form-row">
+          <label for="{{ field.id_for_label }}_room">{{ field.label }}</label>
+          {{ field.as_widget(attrs={'id': field.id_for_label|add:'_room'}) }}
+          {{ field.errors }}
+        </div>
+        {% endwith %}
+      </div>
+      {% with field=form.repair_type %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_room">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_room'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      <div class="form-row">
+        <label for="{{ form.jk_id.id_for_label }}_room">{{ form.jk_id.label }}</label>
+        {{ form.jk_id.as_widget(attrs={'id': form.jk_id.id_for_label|add:'_room'}) }}
+        {{ form.jk_id.errors }}
       </div>
       <div class="form-row">
-        {{ form.jk_name.label_tag }}
-        {{ form.jk_name }}
+        <label for="{{ form.jk_name.id_for_label }}_room">{{ form.jk_name.label }}</label>
+        {{ form.jk_name.as_widget(attrs={'id': form.jk_name.id_for_label|add:'_room'}) }}
+        {{ form.jk_name.errors }}
       </div>
       <div class="form-row">
-        {{ form.house_id.label_tag }}
-        {{ form.house_id }}
+        <label for="{{ form.house_id.id_for_label }}_room">{{ form.house_id.label }}</label>
+        {{ form.house_id.as_widget(attrs={'id': form.house_id.id_for_label|add:'_room'}) }}
+        {{ form.house_id.errors }}
       </div>
       <div class="form-row">
-        {{ form.house_name.label_tag }}
-        {{ form.house_name }}
+        <label for="{{ form.house_name.id_for_label }}_room">{{ form.house_name.label }}</label>
+        {{ form.house_name.as_widget(attrs={'id': form.house_name.id_for_label|add:'_room'}) }}
+        {{ form.house_name.errors }}
       </div>
       <div class="form-row">
-        {{ form.flat_number.label_tag }}
-        {{ form.flat_number }}
+        <label for="{{ form.flat_number.id_for_label }}_room">{{ form.flat_number.label }}</label>
+        {{ form.flat_number.as_widget(attrs={'id': form.flat_number.id_for_label|add:'_room'}) }}
+        {{ form.flat_number.errors }}
       </div>
       <div class="form-row">
-        {{ form.section_number.label_tag }}
-        {{ form.section_number }}
+        <label for="{{ form.section_number.id_for_label }}_room">{{ form.section_number.label }}</label>
+        {{ form.section_number.as_widget(attrs={'id': form.section_number.id_for_label|add:'_room'}) }}
+        {{ form.section_number.errors }}
       </div>
-    </section>
+    </div>
 
-    <!-- Дом (ТОЛЬКО для house) -->
-    <section class="group" data-cat="house">
-      <h3>Дом</h3>
-      {% if form.fields.house_type %}<div class="form-row">{{ form.house_type.label_tag }} {{ form.house_type }}</div>{% endif %}
-      <div class="form-row">{{ form.land_area.label_tag }} {{ form.land_area }}</div>
-      <div class="form-row">{{ form.land_area_unit.label_tag }} {{ form.land_area_unit }}</div>
-      <div class="form-row">{{ form.permitted_land_use.label_tag }} {{ form.permitted_land_use }}</div>
-      <div class="form-row">{{ form.is_land_with_contract.label_tag }} {{ form.is_land_with_contract }}</div>
-      <div class="form-row">{{ form.land_category.label_tag }} {{ form.land_category }}</div>
-      <div class="form-row">{{ form.heating_type.label_tag }} {{ form.heating_type }}</div>
-      <div class="form-row">{{ form.ceiling_height.label_tag }} {{ form.ceiling_height }}</div>
-      <div class="form-row">{{ form.has_terrace.label_tag }} {{ form.has_terrace }}</div>
-      <div class="form-row">{{ form.has_cellar.label_tag }} {{ form.has_cellar }}</div>
-      <div class="form-row">{{ form.power.label_tag }} {{ form.power }}</div>
-      <div class="form-row">{{ form.has_parking.label_tag }} {{ form.has_parking }}</div>
-      <div class="form-row">{{ form.parking_places.label_tag }} {{ form.parking_places }}</div>
-    </section>
-
-    <!-- Коммерция -->
-    <section class="group" data-cat="commercial">
+    <div class="group" data-section="commercial">
       <h3>Коммерция</h3>
-      {% if form.fields.commercial_type %}<div class="form-row">{{ form.commercial_type.label_tag }} {{ form.commercial_type }}</div>{% endif %}
-      <div class="form-row">{{ form.power.label_tag }} {{ form.power }}</div>
-      <div class="form-row">{{ form.has_parking.label_tag }} {{ form.has_parking }}</div>
-      <div class="form-row">{{ form.parking_places.label_tag }} {{ form.parking_places }}</div>
-      <div class="form-row">{{ form.has_ramp.label_tag }} {{ form.has_ramp }}</div>
+      {% if form.fields.commercial_type %}
       <div class="form-row">
-        <label>{{ form.is_rent_by_parts }} {{ form.is_rent_by_parts.label }}</label>
+        <label for="{{ form.commercial_type.id_for_label }}_commercial">{{ form.commercial_type.label }}</label>
+        {{ form.commercial_type.as_widget(attrs={'id': form.commercial_type.id_for_label|add:'_commercial'}) }}
+        {{ form.commercial_type.errors }}
       </div>
+      {% endif %}
+      {% with field=form.total_area %}
       <div class="form-row">
-        {{ form.rent_by_parts_desc.label_tag }}
-        {{ form.rent_by_parts_desc }}
+        <label for="{{ field.id_for_label }}_commercial">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_commercial'}) }}
+        {{ field.errors }}
       </div>
+      {% endwith %}
+      {% with field=form.ceiling_height %}
       <div class="form-row">
-        {{ form.ceiling_height.label_tag }}
-        {{ form.ceiling_height }}
+        <label for="{{ field.id_for_label }}_commercial">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_commercial'}) }}
+        {{ field.errors }}
       </div>
-    </section>
+      {% endwith %}
+      {% with field=form.power %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_commercial">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_commercial'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.has_parking %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_commercial'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.parking_places %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_commercial">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_commercial'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.has_ramp %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_commercial'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.is_rent_by_parts %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_commercial'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.rent_by_parts_desc %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_commercial">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_commercial'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+    </div>
 
-    <!-- Земля -->
-    <section class="group" data-cat="land">
+    <div class="group" data-section="land">
       <h3>Земельный участок</h3>
-      {% if form.fields.land_type %}<div class="form-row">{{ form.land_type.label_tag }} {{ form.land_type }}</div>{% endif %}
-      <div class="form-row">{{ form.land_area.label_tag }} {{ form.land_area }}</div>
-      <div class="form-row">{{ form.land_area_unit.label_tag }} {{ form.land_area_unit }}</div>
-      <div class="form-row">{{ form.permitted_land_use.label_tag }} {{ form.permitted_land_use }}</div>
-      <div class="form-row">{{ form.land_category.label_tag }} {{ form.land_category }}</div>
-      <div class="form-row">{{ form.is_land_with_contract.label_tag }} {{ form.is_land_with_contract }}</div>
-    </section>
+      {% if form.fields.land_type %}
+      <div class="form-row">
+        <label for="{{ form.land_type.id_for_label }}_land">{{ form.land_type.label }}</label>
+        {{ form.land_type.as_widget(attrs={'id': form.land_type.id_for_label|add:'_land'}) }}
+        {{ form.land_type.errors }}
+      </div>
+      {% endif %}
+      {% with field=form.land_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_land">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_land'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.land_area_unit %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_land">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_land'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.permitted_land_use %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_land">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_land'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.land_category %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_land">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_land'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.is_land_with_contract %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_land'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+    </div>
 
-    <section class="group" data-cat="flat,room,house">
+    <div class="group" data-section="garage">
+      <h3>Гараж</h3>
+      {% with field=form.total_area %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_garage">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_garage'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.has_parking %}
+      <div class="form-row">
+        <label>{{ field.as_widget(attrs={'id': field.id_for_label|add:'_garage'}) }} {{ field.label }}</label>
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+      {% with field=form.parking_places %}
+      <div class="form-row">
+        <label for="{{ field.id_for_label }}_garage">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'id': field.id_for_label|add:'_garage'}) }}
+        {{ field.errors }}
+      </div>
+      {% endwith %}
+    </div>
+
+    <section class="group">
       <h3>Удобства</h3>
+      <div class="form-row">
+        <label for="{{ form.furnishing_details.id_for_label }}">{{ form.furnishing_details.label }}</label>
+        {{ form.furnishing_details }}
+        {{ form.furnishing_details.errors }}
+      </div>
       <div class="form-row">
         <label>{{ form.has_internet }} {{ form.has_internet.label }}</label>
       </div>
@@ -309,10 +693,16 @@
         <label>{{ form.has_conditioner }} {{ form.has_conditioner.label }}</label>
       </div>
       <div class="form-row">
-        <label>{{ form.has_phone }} {{ form.has_phone.label }}</label>
+        <label>{{ form.has_refrigerator }} {{ form.has_refrigerator.label }}</label>
       </div>
       <div class="form-row">
-        <label>{{ form.has_ramp }} {{ form.has_ramp.label }}</label>
+        <label>{{ form.has_dishwasher }} {{ form.has_dishwasher.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_shower }} {{ form.has_shower.label }}</label>
+      </div>
+      <div class="form-row">
+        <label>{{ form.has_phone }} {{ form.has_phone.label }}</label>
       </div>
       <div class="form-row">
         <label>{{ form.has_bathtub }} {{ form.has_bathtub.label }}</label>
@@ -349,8 +739,13 @@
           </figcaption>
         </figure>
       {% empty %}
-        <p class="muted">Фото пока нет</p>
+      <p class="muted">Фото пока нет</p>
       {% endfor %}
     </div>
   {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ block.super }}
+  <script src="{% static 'core/form.js' %}"></script>
 {% endblock %}

--- a/core/templates/core/panel_list.html
+++ b/core/templates/core/panel_list.html
@@ -8,12 +8,23 @@
     |
     <a href="/panel/?show=archived">Архив</a>
     |
-    <a href="/panel/?show=all">Все</a>
+    <a href="/panel/?include_archived=1">Все</a>
   </p>
 
-  <form method="get" action="/panel/">
-    <input type="text" name="q" value="{{ q }}" placeholder="Поиск: заголовок / город / ExternalId">
-    <button type="submit">Искать</button>
+  <form method="get" action="/panel/" class="grid-2" style="align-items:end; gap:1rem;">
+    <div>
+      <input type="text" name="q" value="{{ q }}" placeholder="Поиск: заголовок / город / ExternalId">
+      {% if show == "archived" %}
+        <input type="hidden" name="show" value="archived">
+      {% endif %}
+    </div>
+    <div style="display:flex; gap:1rem; align-items:center;">
+      <label style="display:flex; gap:.4rem; align-items:center; margin:0;">
+        <input type="checkbox" name="include_archived" value="1" {% if include_archived %}checked{% endif %}>
+        Показывать архив
+      </label>
+      <button type="submit">Искать</button>
+    </div>
   </form>
 
   <article>
@@ -42,15 +53,22 @@
       {% for p in props %}
         <tr>
           <td>{{ p.pk }}</td>
-          <td>{{ p.title }}</td>
+          <td>
+            <div>{{ p.title }}</div>
+            <div class="badges">
+              {% if p.export_to_cian %}<span class="badge badge-cian">CIAN</span>{% endif %}
+              {% if p.export_to_domklik %}<span class="badge badge-domklik">DomClick</span>{% endif %}
+              {% if p.is_archived %}<span class="badge badge-archived">Архив</span>{% endif %}
+            </div>
+          </td>
           <td>{{ p.city }}</td>
           <td><span class="muted">{{ p.updated_at }}</span></td>
           <td style="display:flex; gap:.5rem;">
             <a href="/panel/edit/{{ p.pk }}/">Открыть</a>
-            {% if p.status == "active" %}
-              <a href="/panel/archive/{{ p.pk }}/">В архив</a>
-            {% elif p.status == "archived" %}
+            {% if p.is_archived %}
               <a href="/panel/restore/{{ p.pk }}/">Вернуть</a>
+            {% else %}
+              <a href="/panel/archive/{{ p.pk }}/">В архив</a>
             {% endif %}
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- replace the legacy combined category with normalized category/operation/subtype fields and rebuild the editor with per-type sections
- add client-side toggling for type-specific blocks, expose house-specific inputs, and avoid saving blank objects on GET
- auto-generate external IDs, filter CIAN exports via the new mapping, and surface export/archive badges with an archived toggle in the list

## Testing
- python -m compileall core

## DEV NOTES
- After merge, run locally:
  - python manage.py makemigrations
  - python manage.py migrate
  - python manage.py runserver
- Test:
  1. /panel/new -> select category=house => see land/heating/house fields
  2. Hidden sections don’t submit values (inspect disabled inputs)
  3. Create without external_id -> it’s generated and unique
  4. No empty records appear by just opening the create page
  5. /panel/export/cian -> contains only export_to_cian=True & non-archived; Category is built via mapping

------
https://chatgpt.com/codex/tasks/task_e_68e168a7f58483209f7b443f50520279