### PR TITLE
ci: ensure pytest installed; use python -m pytest; add pytest.ini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Upgrade pip and install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install dev requirements
+        run: |
+          pip install -r requirements-dev.txt || true
+          pip install pytest pytest-django || true
+
+      - name: Run Django checks
+        run: python manage.py check
+
+      - name: Check migrations
+        run: python manage.py makemigrations --check --dry-run --noinput
+
+      - name: Run tests
+        run: python -m pytest

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -1,0 +1,8 @@
+from django.test import Client, TestCase
+
+
+class Smoke(TestCase):
+    def test_create_page_renders(self):
+        c = Client()
+        response = c.get("/panel/create/?category=house&operation=sale")
+        assert response.status_code in (200, 302, 404)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = realcrm.settings
+python_files = tests.py test_*.py *_tests.py
+addopts = -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-django


### PR DESCRIPTION
## Summary
- add pytest and pytest-django to development requirements
- configure pytest via pytest.ini for Django settings
- ensure CI installs pytest dependencies, runs pytest via python -m pytest, and add a basic smoke test

## Testing
- not run (covered by CI)

No manual steps required after merge. Optionally locally:
  pip install -r requirements-dev.txt
  python manage.py test -q

------
https://chatgpt.com/codex/tasks/task_e_68e1840b63c8832087e54f45e887dfde