### PR TITLE
migrations(state): align domklik field name (state-only rename)

### DIFF
--- a/core/migrations/0013_state_rename_export_to_domklik.py
+++ b/core/migrations/0013_state_rename_export_to_domklik.py
@@ -1,0 +1,32 @@
+from django.core.exceptions import FieldDoesNotExist
+from django.db import migrations
+
+
+class SafeRenameField(migrations.RenameField):
+    def state_forwards(self, app_label, state):
+        try:
+            super().state_forwards(app_label, state)
+        except FieldDoesNotExist:
+            # State already uses the new field name; no further action needed.
+            pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0013_property_is_archived_property_operation_and_more"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                # Никаких DB-операций здесь. БД мы уже приводили ранее (0012).
+            ],
+            state_operations=[
+                SafeRenameField(
+                    model_name="property",
+                    old_name="export_to_domclick",
+                    new_name="export_to_domklik",
+                ),
+            ],
+        ),
+    ]


### PR DESCRIPTION
## Summary
- add a state-only migration that safely renames `export_to_domclick` to `export_to_domklik`

## Testing
- python manage.py makemigrations --check --dry-run --noinput
- python manage.py migrate --noinput
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e24424468c8320a4a0f1d5111be08f