### PR TITLE
fix(migrations): linearize core graph (0013 no-op, 0014 depends on 0013); remove old field name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Check migrations
         run: python manage.py makemigrations --check --dry-run --noinput
 
+      - name: Apply migrations
+        run: python manage.py migrate --noinput
+
       - name: Run tests
-        run: python -m pytest -q
+        run: python -m pytest

--- a/core/migrations/0013_state_rename_export_to_domklik.py
+++ b/core/migrations/0013_state_rename_export_to_domklik.py
@@ -1,14 +1,4 @@
-from django.core.exceptions import FieldDoesNotExist
 from django.db import migrations
-
-
-class SafeRenameField(migrations.RenameField):
-    def state_forwards(self, app_label, state):
-        try:
-            super().state_forwards(app_label, state)
-        except FieldDoesNotExist:
-            # State already uses the new field name; no further action needed.
-            pass
 
 
 class Migration(migrations.Migration):
@@ -17,16 +7,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.SeparateDatabaseAndState(
-            database_operations=[
-                # Никаких DB-операций здесь. БД мы уже приводили ранее (0012).
-            ],
-            state_operations=[
-                SafeRenameField(
-                    model_name="property",
-                    old_name="export_to_domclick",
-                    new_name="export_to_domklik",
-                ),
-            ],
-        ),
+        # no-op: эта миграция теперь ничего не меняет ни в state, ни в БД.
     ]


### PR DESCRIPTION
## Summary
- make the state-only migration 0013 a no-op so the field rename happens only once in the chain
- ensure the CI workflow runs migrate between the migration check and pytest to mirror the local acceptance flow

## Testing
- python manage.py makemigrations --check --dry-run --noinput
- python manage.py migrate --noinput
- python -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68e246c5c7d08320bc767cf135edbdaa