### PR TITLE
fix(migrations): no-op merge 0016 to join 0012 and 0015; enforce single linear core graph

### DIFF
--- a/core/migrations/0016_merge_heads.py
+++ b/core/migrations/0016_merge_heads.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0012_rename_export_to_domklik"),
+        ("core", "0015_merge_linearize"),
+    ]
+
+    operations = [
+        # no-op: this migration only merges heads to linearize the graph
+    ]


### PR DESCRIPTION
## Summary
- add a no-op merge migration to connect the lingering 0012 and 0015 heads so the core app has a single linear history

## Testing
- python manage.py makemigrations --check --dry-run --noinput
- python manage.py migrate --noinput
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e24e2981508320af281eaa06c6b67b