### PR TITLE
fix: use correct Django setting MIGRATION_MODULES for core (switch to core.mig_current)

### DIFF
--- a/realcrm/settings.py
+++ b/realcrm/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = [
     "django_filters",  # библиотека фильтров
 ]
 
-MIGRATIONS_MODULES = {
+MIGRATION_MODULES = {
     "core": "core.mig_current",
 }
 


### PR DESCRIPTION
## Summary
- switch Django configuration to use the correct MIGRATION_MODULES setting for the core app

## Testing
- python manage.py check
- python manage.py makemigrations --check --dry-run --noinput
- python manage.py showmigrations core
- python manage.py migrate --noinput
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e270b6563883208fd386290ce952de