### PR TITLE
Prepare PythonAnywhere deployment settings

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -487,9 +487,8 @@ def export_cian(request):
 
     feeds_dir = os.path.join(settings.MEDIA_ROOT, "feeds")
     os.makedirs(feeds_dir, exist_ok=True)
-    out_path = os.path.join(feeds_dir, "cian.xml")
-    with open(out_path, "wb") as fh:
-        fh.write(xml_bytes)
+    with open(os.path.join(feeds_dir, "cian.xml"), "wb") as f:
+        f.write(xml_bytes)
 
     response = HttpResponse(xml_bytes, content_type="application/xml; charset=utf-8")
     response["Content-Disposition"] = 'attachment; filename="cian.xml"'

--- a/docs/deploy-pythonanywhere.md
+++ b/docs/deploy-pythonanywhere.md
@@ -1,0 +1,59 @@
+# Deploy to PythonAnywhere (Free)
+
+## 1) Clone & setup (Bash console on PythonAnywhere)
+
+```bash
+git clone https://github.com/isty-maker/mini-crm-realty.git
+cd mini-crm-realty
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py collectstatic --noinput
+```
+
+## 2) Create Web app (Dashboard → Web → Add new web app → Manual config, Python 3.12)
+- Virtualenv: `/home/<login>/mini-crm-realty/venv`
+- WSGI file (click “open” and set):
+
+```python
+import sys, os
+project = '/home/<login>/mini-crm-realty'
+if project not in sys.path:
+    sys.path.append(project)
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'realcrm.settings')
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+```
+
+Static files:
+
+- URL: `/static/` → Path: `/home/<login>/mini-crm-realty/staticfiles`
+- URL: `/media/` → Path: `/home/<login>/mini-crm-realty/media`
+
+## 3) Environment variables (Web → Environment)
+
+```
+DEBUG = False
+ALLOWED_HOSTS = <login>.pythonanywhere.com
+CSRF_TRUSTED_ORIGINS = https://<login>.pythonanywhere.com
+SITE_BASE_URL = https://<login>.pythonanywhere.com
+```
+
+Then press **Reload** in the Web tab.
+
+## 4) After each update (deploy steps)
+
+```bash
+cd ~/mini-crm-realty
+source venv/bin/activate
+git pull
+python manage.py migrate --noinput
+python manage.py collectstatic --noinput
+```
+
+Then go to the Web tab and press **Reload**.
+
+## Pages
+
+- Panel: `https://<login>.pythonanywhere.com/panel/`

--- a/realcrm/settings.py
+++ b/realcrm/settings.py
@@ -11,9 +11,15 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+
+def _env_list(name: str):
+    raw = os.getenv(name, "")
+    return [x.strip() for x in raw.split(",") if x.strip()]
 
 
 # Quick-start development settings - unsuitable for production
@@ -23,9 +29,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-61n*lr7yf!1b5_#!esu6a$@q#@9nknvj18hi+y4noq165ixn3o'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv("DEBUG", "False").lower() == "true"
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", "testserver"] + _env_list("ALLOWED_HOSTS")
+
+# Если понадобится для HTTPS-форм/POST на проде:
+CSRF_TRUSTED_ORIGINS = _env_list("CSRF_TRUSTED_ORIGINS")
+
+SITE_BASE_URL = os.getenv("SITE_BASE_URL", "http://127.0.0.1:8000")
 
 
 # Application definition
@@ -116,25 +127,16 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+MEDIA_URL = "/media/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-
-from pathlib import Path
-import os
-
-BASE_DIR = Path(__file__).resolve().parent.parent
-
-STATIC_URL = "/static/"
-
-MEDIA_ROOT = os.path.join(BASE_DIR, "media")
-MEDIA_URL = "/media/"
-
-# Абсолютные ссылки в фидах (на локалке так и оставь):
-SITE_BASE_URL = "http://127.0.0.1:8000"
 
 # Общий секретный ключ доступа к панели (НЕ публиковать)
 SHARED_KEY = "kontinent"


### PR DESCRIPTION
## Summary
- configure static root and environment-driven deployment settings
- ensure the CIAN export writes to `media/feeds/cian.xml`
- add documentation for deploying on PythonAnywhere Free

## Testing
- python manage.py check
- python manage.py makemigrations --check --dry-run --noinput *(fails: generates core/migrations/0012_remove_property_export_to_domclick_and_more.py)*
- python manage.py collectstatic --dry-run
- python manage.py test -q *(fails: manage.py test: error: unrecognized arguments: -q)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dbb87f18832097ba67f0a856eb7c