### PR TITLE
Add PythonAnywhere deployment guide

### DIFF
--- a/docs/deploy_pythonanywhere.md
+++ b/docs/deploy_pythonanywhere.md
@@ -1,0 +1,37 @@
+# Развертывание на PythonAnywhere
+
+## Подготовка
+- Зарегистрируйте бесплатный аккаунт на [PythonAnywhere](https://www.pythonanywhere.com/).
+- Зайдите в консоль Bash: **Dashboard → Open Web tab → Bash console**.
+
+## Клонирование проекта и установка зависимостей
+```bash
+git clone https://github.com/isty-maker/mini-crm-realty.git
+cd mini-crm-realty
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py collectstatic --noinput
+```
+
+## Настройка веб-приложения
+1. Вкладка **Web** → **Add a new web app** → **Manual configuration (Python 3.12)**.
+2. Укажите виртуальное окружение: `/home/<login>/mini-crm-realty/venv`.
+3. В разделе **Code** пропишите `realcrm.settings` в качестве Django settings module.
+4. В **Static files** добавьте:
+   - URL: `/static/` → путь: `/home/<login>/mini-crm-realty/staticfiles`
+   - URL: `/media/` → путь: `/home/<login>/mini-crm-realty/media`
+
+## Переменные окружения (Web → Environment variables)
+```
+DEBUG=False
+ALLOWED_HOSTS=<login>.pythonanywhere.com
+CSRF_TRUSTED_ORIGINS=https://<login>.pythonanywhere.com
+SITE_BASE_URL=https://<login>.pythonanywhere.com
+```
+
+## Завершение
+1. Нажмите **Reload** на вкладке **Web**.
+2. Проверьте админку: `https://<login>.pythonanywhere.com/admin/`.
+3. Убедитесь, что фиды доступны: `https://<login>.pythonanywhere.com/media/feeds/cian.xml`.


### PR DESCRIPTION
## Summary
- add a detailed deployment guide for hosting the project on PythonAnywhere
- document required setup steps including environment variables and static/media configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e18213c8832095d93af143727696