### PR TITLE
Add normalized deployment docs and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Mini CRM Realty
+
+## Установка
+1. Убедитесь, что установлен **Python 3.12**.
+2. Создайте и активируйте виртуальное окружение:
+   ```bash
+   python3.12 -m venv venv
+   source venv/bin/activate
+   ```
+3. Установите зависимости проекта:
+   ```bash
+   pip install -r requirements.txt -r requirements-extra.txt
+   ```
+
+## Запуск
+1. Примените миграции базы данных:
+   ```bash
+   python manage.py migrate
+   ```
+2. Запустите локальный сервер разработки:
+   ```bash
+   python manage.py runserver
+   ```
+
+## Деплой на PythonAnywhere
+Подробная инструкция доступна в [docs/deploy_pa_NEW.md](docs/deploy_pa_NEW.md).
+
+## Экспорт данных
+- В админке доступен экспорт по адресу `/panel/export/cian`.
+- Сгенерированный файл выгрузки сохраняется в `media/feeds/cian.xml`.

--- a/docs/deploy_pa_NEW.md
+++ b/docs/deploy_pa_NEW.md
@@ -1,0 +1,37 @@
+# Развертывание на PythonAnywhere
+
+## Подготовка
+- Зарегистрируйте бесплатный аккаунт на [PythonAnywhere](https://www.pythonanywhere.com/).
+- Откройте консоль Bash: **Dashboard → Open Web tab → Bash console**.
+
+## Клонирование проекта и установка зависимостей
+```bash
+git clone https://github.com/isty-maker/mini-crm-realty.git
+cd mini-crm-realty
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt -r requirements-extra.txt
+python manage.py migrate
+python manage.py collectstatic --noinput
+```
+
+## Настройка веб-приложения
+1. На вкладке **Web** создайте приложение: **Add a new web app → Manual configuration (Python 3.12)**.
+2. Укажите виртуальное окружение: `/home/<login>/mini-crm-realty/venv`.
+3. В разделе **Code** установите `realcrm.settings` как Django settings module.
+4. В **Static files** добавьте:
+   - URL: `/static/` → путь: `/home/<login>/mini-crm-realty/staticfiles`
+   - URL: `/media/` → путь: `/home/<login>/mini-crm-realty/media`
+
+## Переменные окружения (Web → Environment variables)
+```
+DEBUG=False
+ALLOWED_HOSTS=<login>.pythonanywhere.com
+CSRF_TRUSTED_ORIGINS=https://<login>.pythonanywhere.com
+SITE_BASE_URL=https://<login>.pythonanywhere.com
+```
+
+## Завершение
+1. Нажмите **Reload** на вкладке **Web**.
+2. Проверьте админку: `https://<login>.pythonanywhere.com/admin/`.
+3. Убедитесь, что фиды доступны: `https://<login>.pythonanywhere.com/media/feeds/cian.xml`.


### PR DESCRIPTION
## Summary
- add a UTF-8 README with installation, run, deployment, and export instructions
- provide a cleaned PythonAnywhere deployment guide that installs requirements.txt together with requirements-extra.txt

## Testing
- python manage.py check
- python manage.py makemigrations --check --dry-run
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3e25fdf308320a667098f6382a015