### PR TITLE
Hotfix — DB diagnose & repai

### DIFF
--- a/realcrm/urls.py
+++ b/realcrm/urls.py
@@ -6,6 +6,7 @@ from core import views as core_views
 
 urlpatterns = [
     path("healthz/", core_views.healthz, name="healthz"),
+    path("healthz/dbinfo/", core_views.dbinfo, name="dbinfo"),
     path("panel/", core_views.panel_list, name="panel_list"),
     path("panel/new/", core_views.panel_new, name="panel_new"),
     path("panel/create/", core_views.panel_create, name="panel_create"),


### PR DESCRIPTION
## Summary
- add a shared-key protected `/healthz/dbinfo/` endpoint exposing sqlite path, photo schema and core migration status
- keep SQLite database path absolute and guarded squash override flag reference in settings

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e56256f4a08320aa808c6644b1958f