### PR TITLE
Add DB diagnostics endpoints and repair core_photo columns

### DIFF
--- a/core/migrations/0003_repair_photo_columns.py
+++ b/core/migrations/0003_repair_photo_columns.py
@@ -1,0 +1,22 @@
+from django.db import migrations, connection
+
+
+def ensure_photo_columns(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute("PRAGMA table_info(core_photo)")
+        cols = [row[1] for row in cursor.fetchall()]
+        if "image" not in cols:
+            cursor.execute("ALTER TABLE core_photo ADD COLUMN image varchar(100) NULL")
+        if "url" not in cols:
+            cursor.execute("ALTER TABLE core_photo ADD COLUMN url varchar(200) NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0002_photo_image"),
+    ]
+
+    operations = [
+        migrations.RunPython(ensure_photo_columns, migrations.RunPython.noop),
+    ]

--- a/core/views.py
+++ b/core/views.py
@@ -62,6 +62,23 @@ def dbinfo(request):
     return JsonResponse(info)
 
 
+@shared_key_required
+def logtail(request):
+    """Return the tail of the production error log (200 lines)."""
+
+    path = "/var/log/isty.pythonanywhere.com.error.log"
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            tail = "".join(f.readlines()[-200:])
+        return HttpResponse(tail, content_type="text/plain")
+    except Exception as e:  # pragma: no cover - diagnostics only
+        return HttpResponse(
+            f"cannot read log: {e}",
+            content_type="text/plain",
+            status=500,
+        )
+
+
 def _normalize_category(value):
     if not value:
         return None

--- a/realcrm/urls.py
+++ b/realcrm/urls.py
@@ -7,6 +7,7 @@ from core import views as core_views
 urlpatterns = [
     path("healthz/", core_views.healthz, name="healthz"),
     path("healthz/dbinfo/", core_views.dbinfo, name="dbinfo"),
+    path("healthz/logtail/", core_views.logtail, name="logtail"),
     path("panel/", core_views.panel_list, name="panel_list"),
     path("panel/new/", core_views.panel_new, name="panel_new"),
     path("panel/create/", core_views.panel_create, name="panel_create"),


### PR DESCRIPTION
## Summary
- add a dbinfo diagnostic endpoint that reports sqlite path, core_photo columns, and migration state
- expose a shared-key-protected tail of the production error log for troubleshooting
- provide a defensive migration to add missing image/url columns on core_photo tables

## Testing
- python manage.py makemigrations --check
- python manage.py migrate --noinput
- python manage.py check
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68e569c8cf0c832083f74dad7ae397c7