### PR TITLE
Add GitHub Gist log uploader script and setup instructions

### DIFF
--- a/deploy/pythonanywhere.md
+++ b/deploy/pythonanywhere.md
@@ -39,6 +39,7 @@ Web → Environment variables:
   CSRF_TRUSTED_ORIGINS=https://<username>.pythonanywhere.com
   SITE_BASE_URL=https://<username>.pythonanywhere.com
   SHARED_KEY=kontinent  # замени при необходимости
+  GITHUB_GIST_TOKEN=<твой GitHub personal access token с правом gist>
 
 Static files:
   /static/ → /home/<username>/mini-crm-realty/staticfiles
@@ -97,3 +98,12 @@ Static files:
   ```
 - Во вкладке **Web** нажми **Reload**.
 - Готово — изменения на сайте.
+
+## 9. Автоэкспорт логов ошибок в GitHub Gist
+
+- Убедись, что переменная окружения `GITHUB_GIST_TOKEN` добавлена (см. раздел выше).
+- В Bash-консоли вручную запусти `python gist_uploader.py`, чтобы создать первый Gist и получить ссылку на `RAW_URL`.
+- На вкладке **Tasks** → **Add a new task** настрой задание:
+  - Command: `bash -lc "cd ~/mini-crm-realty && workon mini-crm-realty && python gist_uploader.py"`
+  - Schedule: every **10 minutes**.
+- После сохранения задание будет обновлять Gist свежими логами каждые 10 минут. Ссылка `RAW_URL` остаётся постоянной — её можно использовать для просмотра последних ошибок.

--- a/gist_uploader.py
+++ b/gist_uploader.py
@@ -1,0 +1,45 @@
+import json
+import os
+
+import requests
+
+LOG_PATH = "/var/log/isty.pythonanywhere.com.error.log"
+TOKEN = os.getenv("GITHUB_GIST_TOKEN")
+GIST_ID_FILE = os.path.expanduser("~/.gist_id")
+
+if not TOKEN:
+    print("❌ Нет токена (GITHUB_GIST_TOKEN).")
+    raise SystemExit(1)
+
+if not os.path.exists(LOG_PATH):
+    print(f"❌ Лог-файл не найден: {LOG_PATH}")
+    raise SystemExit(1)
+
+with open(LOG_PATH, "r", encoding="utf-8") as f:
+    lines = f.readlines()[-300:]
+content = "".join(lines)
+headers = {"Authorization": f"token {TOKEN}"}
+
+if os.path.exists(GIST_ID_FILE):
+    with open(GIST_ID_FILE, "r", encoding="utf-8") as f:
+        gist_id = f.read().strip()
+    url = f"https://api.github.com/gists/{gist_id}"
+    payload = {"files": {"error.log": {"content": content}}}
+    r = requests.patch(url, headers=headers, data=json.dumps(payload))
+    if r.status_code == 200:
+        print("✅ Gist обновлён")
+        print("RAW_URL:", r.json()["files"]["error.log"]["raw_url"])
+    else:
+        print("❌ Ошибка обновления:", r.status_code, r.text)
+else:
+    data = {"public": True, "files": {"error.log": {"content": content}}}
+    r = requests.post("https://api.github.com/gists", headers=headers, data=json.dumps(data))
+    if r.status_code == 201:
+        gist = r.json()
+        gist_id = gist["id"]
+        with open(GIST_ID_FILE, "w", encoding="utf-8") as f:
+            f.write(gist_id)
+        print("✅ Gist создан!")
+        print("RAW_URL:", gist["files"]["error.log"]["raw_url"])
+    else:
+        print("❌ Ошибка создания:", r.status_code, r.text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==5.2.7
 python-dotenv>=1.0.1,<2.0
 django-filter>=24.2,<25
 Pillow>=10
+requests>=2.31.0,<3


### PR DESCRIPTION
## Summary
- add a standalone script that uploads the latest error log lines to a persistent GitHub Gist
- document the required environment variable and scheduled task setup for PythonAnywhere
- include the requests dependency to support the uploader script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57902987c8320811b5f75b45d72e0