### PR TITLE
Normalize Photo schema and update references

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -311,16 +311,17 @@ class PhotoForm(forms.ModelForm):
 
     class Meta:
         model = Photo
-        fields = ["image", "url", "is_default"]
+        fields = ["image", "full_url", "is_default"]
 
     def clean(self):
         cleaned = super().clean()
         image = cleaned.get("image")
-        url = (cleaned.get("url") or "").strip()
-        if not image and not url:
+        full_url = (cleaned.get("full_url") or "").strip()
+        if not image and not full_url:
             raise forms.ValidationError(
                 "Необходимо загрузить файл или указать ссылку."
             )
+        cleaned["full_url"] = full_url
         return cleaned
 
 

--- a/core/management/commands/export_cian.py
+++ b/core/management/commands/export_cian.py
@@ -54,7 +54,14 @@ class Command(BaseCommand):
 
             pics = SubElement(o, "photos")
             for ph in p.photos.all():
-                add(pics, "photo", f"{settings.SITE_BASE_URL}{ph.image.url}")
+                src = ph.src
+                if not src:
+                    continue
+                if src.startswith("http://") or src.startswith("https://"):
+                    url = src
+                else:
+                    url = f"{settings.SITE_BASE_URL}{src}"
+                add(pics, "photo", url)
 
         out_dir = Path(settings.MEDIA_ROOT) / "feeds"
         out_dir.mkdir(parents=True, exist_ok=True)

--- a/core/management/commands/export_yandex.py
+++ b/core/management/commands/export_yandex.py
@@ -34,7 +34,14 @@ class Command(BaseCommand):
             SubElement(offer, "description").text = p.description or p.title
 
             for ph in p.photos.all():
-                SubElement(offer, "image").text = f"{settings.SITE_BASE_URL}{ph.image.url}"
+                src = ph.src
+                if not src:
+                    continue
+                if src.startswith("http://") or src.startswith("https://"):
+                    url = src
+                else:
+                    url = f"{settings.SITE_BASE_URL}{src}"
+                SubElement(offer, "image").text = url
 
         out_dir = Path(settings.MEDIA_ROOT) / "feeds"
         out_dir.mkdir(parents=True, exist_ok=True)

--- a/core/migrations/0004_photo_schema_normalize.py
+++ b/core/migrations/0004_photo_schema_normalize.py
@@ -1,0 +1,57 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+
+def copy_url_to_full_url(apps, schema_editor):
+    Photo = apps.get_model("core", "Photo")
+    for photo in Photo.objects.all():
+        url = getattr(photo, "url", None)
+        full_url = getattr(photo, "full_url", None)
+        if url and not full_url:
+            photo.full_url = url
+            photo.save(update_fields=["full_url"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0003_repair_photo_columns"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="photo",
+            old_name="prop",
+            new_name="property",
+        ),
+        migrations.AddField(
+            model_name="photo",
+            name="full_url",
+            field=models.URLField(blank=True, null=True),
+        ),
+        migrations.RunPython(copy_url_to_full_url, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name="photo",
+            name="url",
+        ),
+        migrations.AddField(
+            model_name="photo",
+            name="sort",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="photo",
+            name="created_at",
+            field=models.DateTimeField(auto_now_add=True, default=django.utils.timezone.now),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name="photo",
+            name="image",
+            field=models.ImageField(blank=True, null=True, upload_to="photos/%Y/%m/%d"),
+        ),
+        migrations.AlterModelOptions(
+            name="photo",
+            options={"ordering": ["-is_default", "sort", "id"]},
+        ),
+    ]

--- a/core/tests/test_photos.py
+++ b/core/tests/test_photos.py
@@ -23,7 +23,7 @@ class PhotoUploadTest(TestCase):
         url = reverse("panel_add_photo", kwargs={"pk": self.prop.id})
         resp = self.client.post(url, {"is_default": "on", "image": file})
         self.assertIn(resp.status_code, (302, 303))
-        ph = Photo.objects.filter(prop=self.prop).first()
+        ph = Photo.objects.filter(property=self.prop).first()
         self.assertTrue(ph and ph.image)
         from PIL import Image as PILImage
 

--- a/core/views.py
+++ b/core/views.py
@@ -390,9 +390,9 @@ def panel_add_photo(request, pk):
     form = PhotoForm(request.POST, request.FILES)
     if form.is_valid():
         ph = form.save(commit=False)
-        ph.prop = prop
+        ph.property = prop
         if form.cleaned_data.get("is_default"):
-            Photo.objects.filter(prop=prop).update(is_default=False)
+            Photo.objects.filter(property=prop).update(is_default=False)
             ph.is_default = True
         ph.save()
     return HttpResponseRedirect(reverse("panel_edit", kwargs={"pk": pk}))
@@ -524,7 +524,7 @@ def export_cian(request):
             photos_el = SubElement(obj, "Photos")
             for p in photos_qs.all():
                 ph = SubElement(photos_el, "PhotoSchema")
-                _t(ph, "FullUrl", getattr(p, "image_url", "") or getattr(p, "url", ""), always=True)
+                _t(ph, "FullUrl", getattr(p, "src", ""), always=True)
                 if getattr(p, "is_default", False):
                     _t(ph, "IsDefault", True, always=True)
 


### PR DESCRIPTION
## Summary
- align the Photo model with the current schema by adding nullable `full_url`, renaming the property relation, and introducing sorting metadata
- add an explicit migration to rename/remove legacy columns and keep existing URL data
- update forms, views, exports, and tests to rely on `full_url`/`src` instead of the removed `url` field

## Testing
- python manage.py makemigrations --check
- python manage.py migrate --noinput
- python manage.py test -q

------
https://chatgpt.com/codex/tasks/task_e_68e59a33fc488320a9099367e690728a