### PR TITLE
Implement multi-photo management improvements

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -311,6 +311,17 @@ class Photo(models.Model):
         except Exception:
             pass
 
+    def human_size(self):
+        try:
+            size = self.image.size
+        except Exception:
+            return ""
+        for unit in ["Б", "КБ", "МБ"]:
+            if size < 1024 or unit == "МБ":
+                return f"{size:.0f} {unit}" if unit == "Б" else f"{size / 1024:.1f} {unit}"
+            size /= 1024
+        return ""
+
     @builtins.property
     def src(self):
         try:

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -773,32 +773,40 @@
   {% if prop %}
     <hr>
     <h3>Фотографии</h3>
-    <form action="{% url 'panel_add_photo' pk=prop.id %}" method="post" enctype="multipart/form-data">
+    <form method="post" action="{% url 'panel_add_photo' pk=prop.id %}" enctype="multipart/form-data">
       {% csrf_token %}
-      <input type="file" id="photo-input" name="image" accept="image/*">
-      <input type="url" name="full_url" placeholder="https://example.com/photo.jpg" style="margin-left:.5rem; min-width: 260px;">
-      <label style="margin-left:.5rem;">
-        <input type="checkbox" name="is_default"> Сделать главным
-      </label>
+      <div class="form-row">
+        <label>Файлы (можно выбрать несколько)</label>
+        <input type="file" name="images" multiple accept="image/*">
+      </div>
+      <div class="form-row row-2">
+        <div><input type="url" name="full_url" placeholder="или URL изображения"></div>
+        <label style="display:flex;gap:.4rem;align-items:center;">
+          <input type="checkbox" name="is_default" value="1">
+          Сделать главное
+        </label>
+      </div>
       <button type="submit">Загрузить</button>
     </form>
 
-    <div id="photo-preview-wrapper">
-      <img id="photo-preview" style="max-width: 320px; display:none;" alt="preview">
-    </div>
-
-    <div id="photos" class="panel-photos" style="display:flex; flex-wrap:wrap; gap:1rem; margin-top:1rem;">
+    <div id="photos" class="photos" style="display:flex; flex-wrap:wrap; gap:1rem; margin-top:1rem;">
       {% for ph in photos %}
-        <div class="panel-photo" data-photo-id="{{ ph.id }}" style="border:1px solid #ddd; padding:.5rem; max-width:200px;">
-          {% if ph.is_default %}<div style="font-weight:bold; margin-bottom:.25rem;">[главное]</div>{% endif %}
+        <div class="photo" data-photo-id="{{ ph.id }}" style="position:relative; border:1px solid #ddd; padding:.5rem; max-width:200px;">
+          {% if ph.is_default %}
+            <span class="badge" style="position:absolute;top:6px;left:6px;background:#dff4df;color:#1c6724;">Главное</span>
+          {% endif %}
           {% if ph.src %}
             <img src="{{ ph.src }}" alt="" style="max-width: 100%; height:auto; display:block;">
           {% endif %}
-          <div class="photo-actions" style="display:flex; gap:.4rem; flex-wrap:wrap; margin-top:.5rem;">
-            <button type="button" class="photo-move" data-action="up" title="Переместить вверх">↑</button>
-            <button type="button" class="photo-move" data-action="down" title="Переместить вниз">↓</button>
-            <a href="{% url 'panel_toggle_main' photo_id=ph.id %}">сделать главным</a>
-            <form method="post" action="{% url 'panel_photo_delete' pk=ph.id %}" style="margin:0;">
+          <div class="muted" style="margin-top:.3rem;">
+            {{ ph.human_size }}
+          </div>
+          <div style="display:flex;gap:.4rem;margin-top:.3rem;">
+            <form method="post" action="{% url 'panel_photo_set_default' ph.id %}">
+              {% csrf_token %}
+              <button type="submit">Сделать главным</button>
+            </form>
+            <form method="post" action="{% url 'panel_photo_delete' ph.id %}">
               {% csrf_token %}
               <button class="secondary" type="submit">Удалить</button>
             </form>
@@ -822,52 +830,40 @@
 {% block extra_scripts %}
   {{ block.super }}
   <script src="{% static 'core/form.js' %}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
   <script>
   document.addEventListener("DOMContentLoaded", function () {
-    var input = document.getElementById("photo-input");
-    var img = document.getElementById("photo-preview");
-    if (!input || !img) return;
-    input.addEventListener("change", function (e) {
-      const file = e.target.files && e.target.files[0];
-      if (!file) { img.style.display = "none"; return; }
-      const reader = new FileReader();
-      reader.onload = function (ev) {
-        img.src = ev.target.result;
-        img.style.display = "block";
-      };
-      reader.readAsDataURL(file);
-    });
-    const photosContainer = document.getElementById('photos');
-    if (photosContainer) {
-      photosContainer.addEventListener('click', function (event) {
-        const btn = event.target.closest('button.photo-move');
-        if (!btn) return;
-        event.preventDefault();
-        const card = btn.closest('.panel-photo');
-        if (!card) return;
-        if (btn.dataset.action === 'up') {
-          const prev = card.previousElementSibling;
-          if (prev) {
-            photosContainer.insertBefore(card, prev);
-          }
-        } else if (btn.dataset.action === 'down') {
-          const next = card.nextElementSibling;
-          if (next) {
-            photosContainer.insertBefore(next, card);
-          }
-        }
-      });
+    const list = document.getElementById('photos');
+    const form = document.getElementById('reorderForm');
+    if (!list || !form) return;
+
+    function getCSRF() {
+      const m = document.cookie.match(/csrftoken=([^;]+)/);
+      return m ? m[1] : "";
     }
 
-    const reorderForm = document.getElementById('reorderForm');
-    if (reorderForm) {
-      reorderForm.addEventListener('submit', function (e) {
-        const ids = Array.from(document.querySelectorAll('#photos .panel-photo'))
-          .map(function (el) { return el.dataset.photoId; })
-          .filter(function (id) { return id; });
+    new Sortable(list, {
+      animation: 150,
+      ghostClass: 'drag',
+      onEnd() {
+        const ids = Array.from(document.querySelectorAll('#photos .photo')).map(
+          (el) => el.dataset.photoId
+        );
         document.getElementById('orderInput').value = ids.join(',');
-      });
-    }
+        fetch(form.action, {
+          method: 'POST',
+          headers: { 'X-CSRFToken': getCSRF() },
+          body: new FormData(form),
+        }).catch(() => {});
+      },
+    });
+
+    form.addEventListener('submit', function () {
+      const ids = Array.from(document.querySelectorAll('#photos .photo')).map(
+        (el) => el.dataset.photoId
+      );
+      document.getElementById('orderInput').value = ids.join(',');
+    });
   });
   </script>
 {% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,7 +8,11 @@ urlpatterns = [
     path("", views.panel_list, name="panel_list"),
     path("new/", views.panel_edit, name="panel_new"),      # «новый» = panel_edit без pk
     path("<int:pk>/", views.panel_edit, name="panel_edit"),
-    path("<int:pk>/photo/add/", views.photo_add, name="photo_add"),
+    path(
+        "panel/edit/<int:pk>/add-photo/",
+        views.panel_add_photo,
+        name="panel_add_photo",
+    ),
     path(
         "panel/photo/<int:pk>/delete/",
         views.panel_photo_delete,
@@ -18,6 +22,11 @@ urlpatterns = [
         "panel/<int:prop_id>/photos/reorder/",
         views.panel_photos_reorder,
         name="panel_photos_reorder",
+    ),
+    path(
+        "panel/photo/<int:pk>/set-default/",
+        views.panel_photo_set_default,
+        name="panel_photo_set_default",
     ),
     path("feed/cian.xml", views.export_cian, name="export_cian"),
 ]

--- a/realcrm/urls.py
+++ b/realcrm/urls.py
@@ -15,8 +15,16 @@ urlpatterns = [
     path("panel/edit/<int:pk>/", core_views.panel_edit, name="panel_edit"),
     path("panel/edit/<int:pk>/add-photo/", core_views.panel_add_photo, name="panel_add_photo"),
     path("panel/photo/<int:pk>/delete/", core_views.panel_photo_delete, name="panel_photo_delete"),
-    path("panel/<int:prop_id>/photos/reorder/", core_views.panel_photos_reorder, name="panel_photos_reorder"),
-    path("panel/photo/<int:photo_id>/make-main/", core_views.panel_toggle_main, name="panel_toggle_main"),
+    path(
+        "panel/<int:prop_id>/photos/reorder/",
+        core_views.panel_photos_reorder,
+        name="panel_photos_reorder",
+    ),
+    path(
+        "panel/photo/<int:pk>/set-default/",
+        core_views.panel_photo_set_default,
+        name="panel_photo_set_default",
+    ),
     path("panel/export/cian/", core_views.export_cian, name="export_cian"),
     path("panel/export/cian/check/", core_views.export_cian_check, name="export_cian_check"),
     path("panel/archive/<int:pk>/", core_views.panel_archive, name="panel_archive"),


### PR DESCRIPTION
## Summary
- support multi-file photo uploads with compression safeguards and default photo handling
- refresh the panel photo management UI with Sortable.js reordering, size badges, and default toggles
- expose endpoints for deleting, reordering, and setting default photos while keeping feed ordering consistent

## Testing
- python manage.py test core.tests.test_photos

------
https://chatgpt.com/codex/tasks/task_e_68e64a57a71483209c5c6c8ba0bad1c6