### PR TITLE
Stabilize house form choices and adjust panel grouping

### DIFF
--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -214,6 +214,8 @@
     new Sortable(list, {
       animation: 150,
       fallbackTolerance: 5,
+      draggable: '.photo-card',
+      handle: '.photo-thumb img',
     });
 
     const reorderForm = document.getElementById('reorderForm');

--- a/core/views.py
+++ b/core/views.py
@@ -641,7 +641,7 @@ def _panel_form_context(form, prop, photos):
     cat_fields = fields_for_category(category_value, operation_value)
     cat_fields = [name for name in cat_fields if name in form.fields]
 
-    field_groups, category_misc = group_fields(cat_fields, category_value)
+    field_groups, category_misc = group_fields(cat_fields, category_value, operation_value)
 
     bound_groups = []
     for title, names in field_groups:

--- a/tests/test_ui_category_sets.py
+++ b/tests/test_ui_category_sets.py
@@ -38,7 +38,10 @@ def test_room_sale_has_room_specific_but_not_flat_or_land():
 
 def test_grouping_house_is_sensible():
     names = sorted(fields_for_category("house", "sale"))
-    groups, misc = group_fields(names, "house")
-    assert "Дом и участок" in [title for title, _ in groups]
-    assert "Инженерия (дом/участок)" in [title for title, _ in groups]
+    groups, misc = group_fields(names, "house", "sale")
+    titles = [title for title, _ in groups]
+    assert "Площадь и планировка" in titles
+    assert "Дом и участок" in titles
+    assert "Инженерия (дом/участок)" in titles
+    assert "Удобства" not in titles, "sale house should hide amenities section"
     assert misc == []


### PR DESCRIPTION
## Summary
- fetch property field choices from model metadata with safe fallbacks and reorganize the house field groups to include floors/repair while skipping amenities for sale operations
- limit photo drag handles to the image element and pass the operation context into group_fields when rendering panel forms
- update the house grouping UI test expectations for the new layout

## Testing
- pytest tests/test_ui_category_sets.py::test_grouping_house_is_sensible -q


------
https://chatgpt.com/codex/tasks/task_e_68f00c1cbaa08320b085aafa69e0604b