### PR TITLE
Fix house choice fields and CIАН mapping aliases

### DIFF
--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -86,16 +86,6 @@
       {% endwith %}
     </section>
 
-    <section class="group">
-      <h3>Карточка</h3>
-      {% with field=form.title %}
-      <div class="form-row">
-        {{ field.label_tag }} {{ field }}
-        {% include "core/includes/field_errors.html" %}
-      </div>
-      {% endwith %}
-    </section>
-
     {% for group_title, fields in field_groups %}
       <section class="group">
         <h3>{{ group_title }}</h3>

--- a/core/views.py
+++ b/core/views.py
@@ -641,7 +641,11 @@ def _panel_form_context(form, prop, photos):
     cat_fields = fields_for_category(category_value, operation_value)
     cat_fields = [name for name in cat_fields if name in form.fields]
 
-    field_groups, category_misc = group_fields(cat_fields, category_value)
+    field_groups, category_misc = group_fields(
+        cat_fields,
+        category_value,
+        operation_value,
+    )
 
     bound_groups = []
     for title, names in field_groups:


### PR DESCRIPTION
## Summary
- ensure house heating/material/condition dropdowns read choices from model metadata and switch parking to a select widget while hiding internal bargain fields
- reorganize panel field groups so house-specific attributes, room layout, and optional coordinates render correctly for each operation
- add CIАН feed aliases for house enums (including parking) and propagate operation context when grouping fields

## Testing
- python manage.py makemigrations --check --dry-run --noinput
- python manage.py test -q

------
https://chatgpt.com/codex/tasks/task_e_68f09d9504d8832092803544e8eb77f6