### PR TITLE
Improve panel UI layout and photo interactions

### DIFF
--- a/core/static/core/panel.css
+++ b/core/static/core/panel.css
@@ -1,3 +1,48 @@
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: #2455a6;
+  text-decoration: none;
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.form-toolbar {
+  position: sticky;
+  top: calc(var(--app-header-height) + 0.5rem);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.4rem 0;
+  margin-bottom: 1.1rem;
+  background: #fff;
+  border-bottom: 1px solid #e1e5f2;
+  box-shadow: 0 6px 12px -12px rgba(31, 48, 84, 0.35);
+}
+
+.form-toolbar h1 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.form-toolbar-info {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.form-toolbar-save {
+  white-space: nowrap;
+}
+
 .photo-bulk-actions {
   display: flex;
   gap: 0.5rem;
@@ -8,8 +53,8 @@
 
 #photos {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.85rem;
   margin-top: 0.75rem;
 }
 
@@ -17,78 +62,107 @@
   display: block;
 }
 
-.photo-card {
-  background: transparent;
-  border: 0;
-  border-radius: 6px;
-  margin: 0;
-  padding: 0;
-  position: relative;
+.photo-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
 }
 
-.photo-card.selected {
-  outline: 2px solid #4a90e2;
-  outline-offset: 2px;
+.photo-item.selected .photo-thumb {
+  box-shadow: 0 0 0 2px rgba(45, 108, 223, 0.45);
 }
 
-.photo-card label.photo-thumb {
+.photo-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  cursor: grab;
+}
+
+.photo-tile:active {
+  cursor: grabbing;
+}
+
+.photo-thumb {
   display: block;
-  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid #dce1f4;
+  background: #f6f7fb;
 }
 
-.photo-card img {
+.photo-thumb input {
+  position: absolute;
+  top: 0.55rem;
+  left: 0.55rem;
+  z-index: 2;
+}
+
+.photo-thumb img {
   display: block;
   width: 100%;
-  height: 150px;
+  height: 160px;
   object-fit: cover;
-  border-radius: 6px;
+  border-radius: 8px;
 }
 
-.photo-actions {
+.photo-info {
   display: flex;
-  gap: 0.5rem;
   align-items: center;
-  flex-wrap: nowrap;
-  margin-top: 0.35rem;
-  white-space: nowrap;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: #4f5870;
 }
 
-.photo-actions form {
+.photo-info .badge {
+  background: #ffd95c;
+  color: #4a3b00;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.photo-info .size {
+  margin-left: auto;
+  color: #6a7189;
+  font-size: 0.78rem;
+}
+
+.photo-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.photo-controls form {
   margin: 0;
 }
 
-.photo-actions button {
-  padding: 0.25rem 0.5rem;
+.photo-controls button {
+  padding: 0.25rem 0.55rem;
   font-size: 0.85rem;
-  flex-shrink: 0;
-}
-
-.photo-card.no-rotate [data-action="rotate"] {
-  display: none;
-}
-
-.photo-card .badge {
-  background: #ffcc00;
-  padding: 0.1rem 0.35rem;
-  border-radius: 4px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  flex-shrink: 0;
-}
-
-.photo-card .size {
-  color: #777;
-  font-size: 0.75rem;
-  margin-left: auto;
-  flex-shrink: 0;
 }
 
 @media (max-width: 720px) {
-  #photos {
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  .form-toolbar {
+    top: calc(var(--app-header-height) + 0.4rem);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.65rem;
   }
 
-  .photo-card img {
-    height: 120px;
+  .form-toolbar-save {
+    align-self: flex-end;
+  }
+
+  #photos {
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  }
+
+  .photo-thumb img {
+    height: 130px;
   }
 }

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -7,8 +7,20 @@
   <title>{% block title %}Мини-CRM{% endblock %}</title>
   <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@2.0.6/css/pico.min.css">
   <style>
+    :root {
+      --app-header-height: 3.6rem;
+      --app-header-bg: #fff;
+      --app-header-border: #d7dbeb;
+      --app-primary: #2d6cdf;
+      --app-primary-hover: #2455a6;
+      --app-primary-active: #1d4a8f;
+      --app-primary-contrast: #fff;
+    }
+
     html { font-size: 14px; }
+    body { margin: 0; }
     main.container { max-width: 1100px; }
+    .page-content { padding: 1.5rem 0 3rem; }
     .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
     .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
     .muted { color: #667; font-size: .9rem; }
@@ -17,14 +29,121 @@
     h1 { font-size: 1.6rem; margin: .6rem 0; }
     h2 { font-size: 1.3rem; margin: .5rem 0; }
     h3 { font-size: 1.05rem; margin: .45rem 0; }
-    .btn { display: inline-flex; align-items: center; gap: .25rem; padding: .25rem .6rem; border: 1px solid #ccd; border-radius: .35rem; background: #f7f8fb; color: inherit; text-decoration: none; font-size: .95rem; line-height: 1.3; }
-    .btn:hover { background: #eef1f7; }
-    .btn.secondary { background: #e7ebf6; border-color: #c5cadb; }
-    .btn.secondary:hover { background: #dce2f2; }
-    .btn-sm { padding: .2rem .45rem; font-size: .85rem; }
-    .btn-danger { border-color: #df6c6c; background: #ffecec; color: #a21818; }
-    .btn-danger:hover { background: #ffdede; }
-    .tag { display: inline-flex; align-items: center; padding: .15rem .45rem; border-radius: .5rem; background: #eef2ff; color: #2f3a5d; font-size: .78rem; font-weight: 600; }
+
+    .app-header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--app-header-bg);
+      border-bottom: 1px solid var(--app-header-border);
+      box-shadow: 0 1px 3px rgba(25, 41, 71, 0.08);
+    }
+
+    .app-header .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.65rem 0;
+    }
+
+    .app-header .brand {
+      font-weight: 700;
+      font-size: 1.05rem;
+      color: #1f2a44;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    .app-header nav {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .btn,
+    button,
+    .button,
+    input[type="button"],
+    input[type="submit"],
+    input[type="reset"] {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: .3rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: .4rem;
+      border: 1px solid var(--app-primary-active);
+      background: var(--app-primary);
+      color: var(--app-primary-contrast);
+      text-decoration: none;
+      font-size: .95rem;
+      line-height: 1.3;
+      cursor: pointer;
+      transition: background-color .15s ease, border-color .15s ease, box-shadow .15s ease;
+    }
+
+    .btn-sm,
+    button.btn-sm {
+      padding: 0.25rem 0.55rem;
+      font-size: .85rem;
+    }
+
+    .btn:hover,
+    button:hover,
+    .button:hover,
+    input[type="button"]:hover,
+    input[type="submit"]:hover,
+    input[type="reset"]:hover {
+      background: var(--app-primary-hover);
+      border-color: var(--app-primary-hover);
+    }
+
+    .btn:focus,
+    button:focus,
+    .button:focus,
+    input[type="button"]:focus,
+    input[type="submit"]:focus,
+    input[type="reset"]:focus {
+      outline: 2px solid rgba(45, 108, 223, 0.35);
+      outline-offset: 2px;
+    }
+
+    .btn:active,
+    button:active,
+    .button:active,
+    input[type="button"]:active,
+    input[type="submit"]:active,
+    input[type="reset"]:active {
+      background: var(--app-primary-active);
+      border-color: var(--app-primary-active);
+    }
+
+    .btn[disabled],
+    button[disabled],
+    input[type="submit"][disabled],
+    input[type="button"][disabled],
+    input[type="reset"][disabled] {
+      cursor: not-allowed;
+      opacity: .65;
+    }
+
+    .btn-danger,
+    button.btn-danger {
+      border-color: #c63535;
+      background: #f56565;
+      color: #fff;
+    }
+
+    .btn-danger:hover,
+    button.btn-danger:hover {
+      background: #e55555;
+      border-color: #e13f3f;
+    }
+
+    .tag { display: inline-flex; align-items: center; padding: .15rem .45rem; border-radius: .5rem; background: #eef2ff; color:#2f3a5d; font-size: .78rem; font-weight: 600; }
     .tag + .tag { margin-left: .25rem; }
     .tag-archived-label { background: #f0f0f0; color: #444; }
     .tag-extid { display: inline-flex; align-items: center; margin-left: .4rem; padding: .05rem .35rem; border-radius: .35rem; border: 1px solid #d3d6e0; background: #f5f7ff; color: #2f3a5d; font-size: .75rem; line-height: 1; vertical-align: baseline; }
@@ -40,14 +159,6 @@
     .badge-cian { background:#dff4df; color:#1c6724; }
     .badge-domklik { background:#dce8ff; color:#1f4f93; }
     .badge-archived { background:#ececec; color:#555; }
-    button,
-    .button,
-    input[type="button"],
-    input[type="submit"],
-    input[type="reset"] {
-      padding: 0.3rem 0.55rem;
-      font-size: 0.92em;
-    }
     input,
     select,
     textarea {
@@ -70,11 +181,18 @@
     table.tbl td.addr { max-width: 420px; overflow: hidden; text-overflow: ellipsis; }
     table.tbl tr.is-archived { opacity: .6; }
     @media (max-width: 720px) {
+      .app-header { --app-header-height: 4.3rem; }
+      .app-header .container { padding: 0.55rem 0; gap: 0.75rem; }
       table.tbl { font-size: .9rem; }
       table.tbl td, table.tbl th { padding: .4rem .45rem; }
       table.tbl td.addr { max-width: 240px; }
-      .btn { font-size: .9rem; }
-      .btn-sm { font-size: .8rem; }
+      .btn,
+      button,
+      input[type="button"],
+      input[type="submit"],
+      input[type="reset"] { font-size: .9rem; }
+      .btn-sm,
+      button.btn-sm { font-size: .8rem; }
     }
     .topbar { display:flex; align-items:center; gap:.5rem; margin:.2rem 0 .6rem; flex-wrap:wrap; }
     .topbar h1 { margin:0; font-size:1.2rem; }
@@ -105,14 +223,17 @@
   {% block extra_head %}{% endblock %}
 </head>
 <body>
-  <main class="container">
-    <nav>
-      <ul><li><strong>Мини-CRM</strong></li></ul>
-      <ul>
-        <li><a href="/panel/">Список</a></li>
-        <li><a href="/panel/new/">+ Создать объект</a></li>
-      </ul>
-    </nav>
+  <header class="app-header">
+    <div class="container">
+      <a href="{% url 'panel_list' %}" class="brand">Мини-CRM</a>
+      <nav>
+        <a href="{% url 'panel_new' %}" class="btn btn-sm">Создать</a>
+        <a href="{% url 'panel_list' %}" class="btn btn-sm">Список</a>
+        <a href="{% url 'panel_list' %}?show=archived" class="btn btn-sm">Архив</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container page-content">
     {% if messages %}
       <div class="messages" style="margin: 1rem 0; display: grid; gap: .5rem;">
         {% for message in messages %}

--- a/core/templates/core/panel_edit.html
+++ b/core/templates/core/panel_edit.html
@@ -6,11 +6,16 @@
   <link rel="stylesheet" href="{% static 'core/panel.css' %}">
 {% endblock %}
 {% block content %}
-  <a href="/panel/">&larr; к списку</a>
-  <h1>{{ prop|default:"Новый объект" }}</h1>
+  <a href="{% url 'panel_list' %}" class="back-link">&larr; к списку</a>
 
   <form id="prop-form" method="post" action="{% if prop %}{% url 'panel_edit' pk=prop.id %}{% else %}{% url 'panel_create' %}{% endif %}" data-preserve-scroll="true">
     {% csrf_token %}
+    <div class="form-toolbar">
+      <div class="form-toolbar-info">
+        <h1>{{ prop|default:"Новый объект" }}</h1>
+      </div>
+      <button type="submit" class="form-toolbar-save">Сохранить</button>
+    </div>
     {{ form.non_field_errors }}
     {% for hidden in form.hidden_fields %}
       {{ hidden }}
@@ -147,32 +152,28 @@
 
     <div id="photos" data-empty-text="Фото пока нет">
       {% for ph in photos %}
-        <div class="photo-card{% if not ph.image %} no-rotate{% endif %}"
-             data-photo-id="{{ ph.id }}"
-             {% if ph.image %}data-rotate-url="{% url 'panel_photo_rotate' ph.id %}"{% endif %}>
-          <label class="photo-thumb">
-            <input type="checkbox" class="photo-select" value="{{ ph.id }}">
-            <img src="{{ ph.src }}" alt="Фото {{ forloop.counter }}">
-          </label>
-
-          <div class="photo-actions">
-            {% if ph.image %}
-            <button type="button" data-action="rotate" data-dir="left" title="Повернуть влево">↺</button>
-            <button type="button" data-action="rotate" data-dir="right" title="Повернуть вправо">↻</button>
+        <div class="photo-item" data-photo-id="{{ ph.id }}">
+          <div class="photo-tile">
+            <label class="photo-thumb">
+              <input type="checkbox" class="photo-select" value="{{ ph.id }}">
+              <img src="{{ ph.src }}" alt="Фото {{ forloop.counter }}">
+            </label>
+            {% if ph.is_default or ph.human_size %}
+            <div class="photo-info">
+              {% if ph.is_default %}<span class="badge">Главное</span>{% endif %}
+              {% if ph.human_size %}<span class="size">{{ ph.human_size }}</span>{% endif %}
+            </div>
             {% endif %}
-
+          </div>
+          <div class="photo-controls">
             <form method="post" action="{% url 'panel_photo_set_default' ph.id %}">
               {% csrf_token %}
               <button type="submit" title="Сделать главным">{% if ph.is_default %}★{% else %}☆{% endif %}</button>
             </form>
-
             <form method="post" action="{% url 'panel_photo_delete' ph.id %}">
               {% csrf_token %}
               <button type="submit" title="Удалить">✖</button>
             </form>
-
-            <span class="size">{{ ph.human_size }}</span>
-            {% if ph.is_default %}<span class="badge">Главное</span>{% endif %}
           </div>
         </div>
       {% empty %}
@@ -204,6 +205,8 @@
     new Sortable(list, {
       animation: 150,
       fallbackTolerance: 5,
+      handle: '.photo-tile',
+      draggable: '.photo-item',
     });
 
     const reorderForm = document.getElementById('reorderForm');
@@ -212,7 +215,7 @@
     }
 
     reorderForm.addEventListener('submit', function () {
-      const ids = Array.from(document.querySelectorAll('#photos .photo-card')).map(
+      const ids = Array.from(document.querySelectorAll('#photos .photo-item')).map(
         (el) => el.dataset.photoId
       );
       const orderInput = reorderForm.querySelector('input[name="order"]');


### PR DESCRIPTION
## Summary
- replace the base navigation with a sticky header bar and update the shared button styling to the blue palette
- add a sticky save toolbar to the property form and refresh the back link styling
- reorganize the photo gallery markup/styles so only tiles drag, control buttons stay separate, and rotation actions are removed

## Testing
- pytest *(fails: pytest-django not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f0ad5163b48320aa4ee2e7466a8044